### PR TITLE
adds Text encoding

### DIFF
--- a/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeKeyedEncodingContainer.swift
+++ b/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeKeyedEncodingContainer.swift
@@ -289,6 +289,26 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
             // Automerge supports it as a primitive value type.
             let downcastCounter = value as! Counter
             try document.put(obj: objectId, key: key.stringValue, value: downcastCounter.toScalarValue())
+        case is Text.Type:
+            // Capture and override the default encodable pathing for Counter since
+            // Automerge supports it as a primitive value type.
+            let downcastText = value as! Text
+            // FIXME: check to see if the object exists here before just splatting a new one into place
+            let textNode = try document.putObject(obj: objectId, key: key.stringValue, ty: .Text)
+
+            // Iterate through
+            let currentText = try! document.text(obj: textNode).utf8
+            let diff: CollectionDifference<String.UTF8View.Element> = downcastText.value.utf8
+                .difference(from: currentText)
+            for change in diff {
+                switch change {
+                case let .insert(offset, element, _):
+                    let char = String(bytes: [element], encoding: .utf8)
+                    try document.spliceText(obj: textNode, start: UInt64(offset), delete: 0, value: char)
+                case let .remove(offset, _, _):
+                    try document.spliceText(obj: textNode, start: UInt64(offset), delete: 1)
+                }
+            }
         default:
             try value.encode(to: newEncoder)
             guard let encodedValue = newEncoder.value else {

--- a/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeUnkeyedEncodingContainer.swift
+++ b/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeUnkeyedEncodingContainer.swift
@@ -96,6 +96,27 @@ struct AutomergeUnkeyedEncodingContainer: UnkeyedEncodingContainer {
             // Automerge supports it as a primitive value type.
             let downcastCounter = value as! Counter
             try self.document.insert(obj: objectId, index: UInt64(count), value: downcastCounter.toScalarValue())
+        case is Text.Type:
+            // Capture and override the default encodable pathing for Counter since
+            // Automerge supports it as a primitive value type.
+            let downcastText = value as! Text
+            // FIXME: check to see if the object exists here before just splatting a new one into place
+            let textNode = try document.putObject(obj: objectId, index: UInt64(count), ty: .Text)
+
+            // FIXME: externalize this code and make common between encoding containers
+            // Iterate through
+            let currentText = try! document.text(obj: textNode).utf8
+            let diff: CollectionDifference<String.UTF8View.Element> = downcastText.value.utf8
+                .difference(from: currentText)
+            for change in diff {
+                switch change {
+                case let .insert(offset, element, _):
+                    let char = String(bytes: [element], encoding: .utf8)
+                    try document.spliceText(obj: textNode, start: UInt64(offset), delete: 0, value: char)
+                case let .remove(offset, _, _):
+                    try document.spliceText(obj: textNode, start: UInt64(offset), delete: 1)
+                }
+            }
         default:
             try value.encode(to: newEncoder)
         }

--- a/Sources/AutomergeSwiftAdditions/Text.swift
+++ b/Sources/AutomergeSwiftAdditions/Text.swift
@@ -1,5 +1,23 @@
 import Foundation
 
-struct Text {
+/// A type that presents a string backed by a Sequential CRDT
+public struct Text: Hashable, Codable {
     var value: String
+
+    // NOTE(heckj): In the near future, we'll have Automerge support for Peritext,
+    // which should map pretty well to AttributedStrings. At that point, this struct
+    // would make a lot more sense exposing an AttributedString by default, with an
+    // optional "slimmed down" regular String from it.
+
+    /// Creates a new Text instance with the string value you provide.
+    /// - Parameter value: The value for the text.
+    public init(_ value: String) {
+        self.value = value
+    }
+}
+
+extension Text: CustomStringConvertible {
+    public var description: String {
+        value
+    }
 }

--- a/Tests/AutomergeSwiftAdditionsTests/AutomergeEncoderTests.swift
+++ b/Tests/AutomergeSwiftAdditionsTests/AutomergeEncoderTests.swift
@@ -36,6 +36,7 @@ final class AutomergeEncoderTests: XCTestCase {
             let date: Date
             let data: Data
             let uuid: UUID
+            let notes: Text
         }
         let automergeEncoder = AutomergeEncoder(doc: doc)
 
@@ -48,7 +49,8 @@ final class AutomergeEncoderTests: XCTestCase {
             count: 5,
             date: earlyDate,
             data: Data("hello".utf8),
-            uuid: UUID(uuidString: "99CEBB16-1062-4F21-8837-CF18EC09DCD7")!
+            uuid: UUID(uuidString: "99CEBB16-1062-4F21-8837-CF18EC09DCD7")!,
+            notes: Text("Something wicked this way comes.")
         )
 
         try automergeEncoder.encode(sample)
@@ -90,12 +92,20 @@ final class AutomergeEncoderTests: XCTestCase {
             try XCTFail("Didn't find: \(String(describing: doc.get(obj: ObjId.ROOT, key: "data")))")
         }
 
-        // debugPrint(try doc.get(obj: ObjId.ROOT, key: "uuid"))
+        // debugPrint(try doc.get(obj: ObjId.ROOT, key: "uuid") as Any)
         if case let .Scalar(.String(uuid_string)) = try doc.get(obj: ObjId.ROOT, key: "uuid") {
             XCTAssertEqual(uuid_string, "99CEBB16-1062-4F21-8837-CF18EC09DCD7")
         } else {
             try XCTFail("Didn't find: \(String(describing: doc.get(obj: ObjId.ROOT, key: "uuid")))")
         }
+
+        if case let .Object(textNode, nodeType) = try doc.get(obj: ObjId.ROOT, key: "notes") {
+            XCTAssertEqual(nodeType, .Text)
+            XCTAssertEqual(try doc.text(obj: textNode), "Something wicked this way comes.")
+        } else {
+            try XCTFail("Didn't find an object at \(String(describing: doc.get(obj: ObjId.ROOT, key: "notes")))")
+        }
+        try debugPrint(doc.get(obj: ObjId.ROOT, key: "notes") as Any)
     }
 
     func testNestedKeyEncode() throws {


### PR DESCRIPTION
- created Text struct that encapsulates string for Text object nodes
- verified simple encoding works (keyed encoding, root object)
- added tests to verify simplest case
- updated diff algorithm from AMText which was incorrectly calculating index offsets for splicing in new text from nothing.