### PR TITLE
Decode scalar

### DIFF
--- a/Sources/AutomergeSwiftAdditions/Codable/AutomergeValue.swift
+++ b/Sources/AutomergeSwiftAdditions/Codable/AutomergeValue.swift
@@ -1,5 +1,6 @@
 import struct Automerge.ObjId
 import enum Automerge.ObjType
+import enum Automerge.ScalarValue
 import enum Automerge.Value
 import Foundation
 
@@ -49,6 +50,31 @@ public enum AutomergeValue: Equatable, Hashable {
     /// This type is reserved for forward compatibility, and is not expected to be created directly.
     case unknown(typeCode: UInt8, data: Data)
     case null
+
+    /// Returns an Automerge ScalarValue from the Codable AutomergeValue when available.
+    /// - Returns: returns nil if the value doesn't map into Automerge's ScalarValue enum.
+    public func scalarValue() -> ScalarValue? {
+        switch self {
+        case let .bytes(data):
+            return .Bytes(data)
+        case let .string(string):
+            return .String(string)
+        case let .uint(uInt64):
+            return .Uint(uInt64)
+        case let .int(int64):
+            return .Int(int64)
+        case let .double(double):
+            return .F64(double)
+        case let .counter(int64):
+            return .Counter(int64)
+        case let .timestamp(int64):
+            return .Timestamp(int64)
+        case let .bool(bool):
+            return .Boolean(bool)
+        default:
+            return nil
+        }
+    }
 
     public static func fromValue(_ value: Value) -> Self {
         switch value {

--- a/Tests/AutomergeSwiftAdditionsTests/AutomergeDecoderTests.swift
+++ b/Tests/AutomergeSwiftAdditionsTests/AutomergeDecoderTests.swift
@@ -21,6 +21,7 @@ final class AutomergeDecoderTests: XCTestCase {
         try! doc.put(obj: ObjId.ROOT, key: "duration", value: .F64(3.14159))
         try! doc.put(obj: ObjId.ROOT, key: "flag", value: .Boolean(true))
         try! doc.put(obj: ObjId.ROOT, key: "count", value: .Int(5))
+        try! doc.put(obj: ObjId.ROOT, key: "uuid", value: .String("99CEBB16-1062-4F21-8837-CF18EC09DCD7"))
 
         let text = try! doc.putObject(obj: ObjId.ROOT, key: "notes", ty: .Text)
         setupCache["notes"] = text
@@ -51,7 +52,7 @@ final class AutomergeDecoderTests: XCTestCase {
             let count: Int
             //            let date: Date
             //            let data: Data
-            //            let uuid: UUID
+            let uuid: UUID
             //            let notes: Text
         }
         let decoder = AutomergeDecoder(doc: doc)
@@ -64,6 +65,9 @@ final class AutomergeDecoderTests: XCTestCase {
         XCTAssertEqual(decodedStruct.duration, 3.14159, accuracy: 0.0001)
         XCTAssertTrue(decodedStruct.flag)
         XCTAssertEqual(decodedStruct.count, 5)
+
+        let expectedUUID = UUID(uuidString: "99CEBB16-1062-4F21-8837-CF18EC09DCD7")!
+        XCTAssertEqual(decodedStruct.uuid, expectedUUID)
     }
 
     func testDecodeTypeMismatch() throws {


### PR DESCRIPTION
drops in decoding capability for any type that conforms to ScalarValueRepresentable to support mapping to internal Automerge ScalarValue types.