### PR TITLE
Resolving Text update issues, increasing test coverage

### DIFF
--- a/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeKeyedEncodingContainer.swift
+++ b/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeKeyedEncodingContainer.swift
@@ -96,7 +96,6 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
         try document.put(obj: objectId, key: key.stringValue, value: .Null)
     }
 
-
     mutating func encode(_ value: Bool, forKey key: Self.Key) throws {
         guard let objectId = self.objectId else {
             throw reportBestError()
@@ -264,20 +263,30 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
             // Capture and override the default encodable pathing for Counter since
             // Automerge supports it as a primitive value type.
             let downcastText = value as! Text
-            // FIXME: check to see if the object exists here before just splatting a new one into place
-            let textNode = try document.putObject(obj: objectId, key: key.stringValue, ty: .Text)
+            let textNodeId: ObjId
+            if let existingNode = try document.get(obj: objectId, key: key.stringValue) {
+                guard case let .Object(textId, .Text) = existingNode else {
+                    throw CodingKeyLookupError
+                        .mismatchedSchema(
+                            "Text Encoding on KeyedContainer at \(self.codingPath) exists and is \(existingNode), not Text."
+                        )
+                }
+                textNodeId = textId
+            } else {
+                textNodeId = try document.putObject(obj: objectId, key: key.stringValue, ty: .Text)
+            }
 
             // Iterate through
-            let currentText = try! document.text(obj: textNode).utf8
+            let currentText = try! document.text(obj: textNodeId).utf8
             let diff: CollectionDifference<String.UTF8View.Element> = downcastText.value.utf8
                 .difference(from: currentText)
             for change in diff {
                 switch change {
                 case let .insert(offset, element, _):
                     let char = String(bytes: [element], encoding: .utf8)
-                    try document.spliceText(obj: textNode, start: UInt64(offset), delete: 0, value: char)
+                    try document.spliceText(obj: textNodeId, start: UInt64(offset), delete: 0, value: char)
                 case let .remove(offset, _, _):
-                    try document.spliceText(obj: textNode, start: UInt64(offset), delete: 1)
+                    try document.spliceText(obj: textNodeId, start: UInt64(offset), delete: 1)
                 }
             }
         default:

--- a/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeSingleValueEncodingContainer.swift
+++ b/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeSingleValueEncodingContainer.swift
@@ -2,6 +2,7 @@ import struct Automerge.Counter
 import class Automerge.Document
 import struct Automerge.ObjId
 import protocol Automerge.ScalarValueRepresentable
+import enum Automerge.Value
 import Foundation
 
 struct AutomergeSingleValueEncodingContainer: SingleValueEncodingContainer {
@@ -181,26 +182,44 @@ struct AutomergeSingleValueEncodingContainer: SingleValueEncodingContainer {
             // Capture and override the default encodable pathing for Counter since
             // Automerge supports it as a primitive value type.
             let downcastText = value as! Text
-            // FIXME: check to see if the object exists here before just splatting a new one into place
 
-            let textNode: ObjId
+            let existingValue: Value?
+            // get any existing value - type of `get` based on the key type
             if let indexToWrite = codingkey.intValue {
-                textNode = try document.putObject(obj: objectId, index: UInt64(indexToWrite), ty: .Text)
+                existingValue = try document.get(obj: objectId, index: UInt64(indexToWrite))
             } else {
-                textNode = try document.putObject(obj: objectId, key: codingkey.stringValue, ty: .Text)
+                existingValue = try document.get(obj: objectId, key: codingkey.stringValue)
+            }
+
+            let textNodeId: ObjId
+            if let existingNode = existingValue {
+                guard case let .Object(textId, .Text) = existingNode else {
+                    throw CodingKeyLookupError
+                        .mismatchedSchema(
+                            "Text Encoding on KeyedContainer at \(self.codingPath) exists and is \(existingNode), not Text."
+                        )
+                }
+                textNodeId = textId
+            } else {
+                // no existing value is there, so create a Text node
+                if let indexToWrite = codingkey.intValue {
+                    textNodeId = try document.putObject(obj: objectId, index: UInt64(indexToWrite), ty: .Text)
+                } else {
+                    textNodeId = try document.putObject(obj: objectId, key: codingkey.stringValue, ty: .Text)
+                }
             }
 
             // Iterate through
-            let currentText = try! document.text(obj: textNode).utf8
+            let currentText = try! document.text(obj: textNodeId).utf8
             let diff: CollectionDifference<String.UTF8View.Element> = downcastText.value.utf8
                 .difference(from: currentText)
             for change in diff {
                 switch change {
                 case let .insert(offset, element, _):
                     let char = String(bytes: [element], encoding: .utf8)
-                    try document.spliceText(obj: textNode, start: UInt64(offset), delete: 0, value: char)
+                    try document.spliceText(obj: textNodeId, start: UInt64(offset), delete: 0, value: char)
                 case let .remove(offset, _, _):
-                    try document.spliceText(obj: textNode, start: UInt64(offset), delete: 1)
+                    try document.spliceText(obj: textNodeId, start: UInt64(offset), delete: 1)
                 }
             }
         default:

--- a/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeUnkeyedEncodingContainer.swift
+++ b/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeUnkeyedEncodingContainer.swift
@@ -108,7 +108,7 @@ struct AutomergeUnkeyedEncodingContainer: UnkeyedEncodingContainer {
                 }
                 textNodeId = textId
             } else {
-                textNodeId = try document.putObject(obj: objectId, index: UInt64(count), ty: .Text)
+                textNodeId = try document.insertObject(obj: objectId, index: UInt64(count), ty: .Text)
             }
 
             let currentText = try! document.text(obj: textNodeId).utf8

--- a/Tests/AutomergeSwiftAdditionsTests/AutomergeEncoderTests.swift
+++ b/Tests/AutomergeSwiftAdditionsTests/AutomergeEncoderTests.swift
@@ -281,4 +281,27 @@ final class AutomergeEncoderTests: XCTestCase {
             try XCTFail("Didn't find an object at \(String(describing: doc.get(obj: ObjId.ROOT, key: "notes")))")
         }
     }
+
+    func testTextEncodingMismatch() throws {
+        let doc = Document()
+        let automergeEncoder = AutomergeEncoder(doc: doc)
+
+        struct InitialTestModel: Codable {
+            var notes: String
+        }
+        struct UpdatedTestModel: Codable {
+            var notes: Text
+        }
+
+        let model = InitialTestModel(notes: "Hello")
+        try automergeEncoder.encode(model)
+        let followupModel = UpdatedTestModel(notes: Text("Hello"))
+
+        XCTAssertThrowsError(
+            try automergeEncoder.encode(followupModel),
+            "Expected mismatched schema to throw error"
+        ) { error in
+            print(error)
+        }
+    }
 }


### PR DESCRIPTION
Check for existing text and update it, instead of blindly overwriting it. Increased test coverage, and verify mismatch error for other types previously encoded.