### PR TITLE
refactoring retrieve function

### DIFF
--- a/Sources/AutomergeSwiftAdditions/Codable/AnyCodingKey+RetrieveObjectId.swift
+++ b/Sources/AutomergeSwiftAdditions/Codable/AnyCodingKey+RetrieveObjectId.swift
@@ -39,7 +39,7 @@ extension AnyCodingKey {
         document: Document,
         path: [CodingKey],
         containerType: EncodingContainerType,
-        strategy: SchemaStrategy = .default
+        strategy: SchemaStrategy
     ) -> Result<(ObjId, AnyCodingKey), Error> {
         // FIXME: refactor the signature (and code flow) to return just an ObjId or Error
         // with .Value container type returning second-to-last ObjectId, and expecting the

--- a/Sources/AutomergeSwiftAdditions/Codable/AnyCodingKey+RetrieveObjectId.swift
+++ b/Sources/AutomergeSwiftAdditions/Codable/AnyCodingKey+RetrieveObjectId.swift
@@ -40,8 +40,7 @@ extension AnyCodingKey {
         path: [CodingKey],
         containerType: EncodingContainerType,
         strategy: SchemaStrategy
-    ) -> Result<(ObjId, AnyCodingKey), Error> {
-        // FIXME: refactor the signature (and code flow) to return just an ObjId or Error
+    ) -> Result<ObjId, Error> {
         // with .Value container type returning second-to-last ObjectId, and expecting the
         // caller to know they'll need to special case whatever they do with the final piece.
 
@@ -93,7 +92,7 @@ extension AnyCodingKey {
         if path.isEmpty {
             switch containerType {
             case .Key:
-                return .success((ObjId.ROOT, AnyCodingKey.ROOT))
+                return .success(ObjId.ROOT)
             case .Index:
                 return .failure(
                     CodingKeyLookupError
@@ -399,7 +398,7 @@ extension AnyCodingKey {
                             case .Map:
                                 if containerType == .Key {
                                     tracePrint("Found Object container with ObjectId \(objId).")
-                                    return .success((objId, AnyCodingKey("")))
+                                    return .success(objId)
                                 } else {
                                     return .failure(
                                         CodingKeyLookupError
@@ -413,7 +412,7 @@ extension AnyCodingKey {
                                 //                            objType))
                                 if containerType == .Index {
                                     tracePrint("Found List container with ObjectId \(objId).")
-                                    return .success((objId, AnyCodingKey("")))
+                                    return .success(objId)
                                 } else {
                                     return .failure(
                                         CodingKeyLookupError
@@ -456,7 +455,7 @@ extension AnyCodingKey {
                                     indent: path.count - 1,
                                     "Created new List container with ObjectId \(newObjectId)."
                                 )
-                                return .success((newObjectId, AnyCodingKey("")))
+                                return .success(newObjectId)
                             } else {
                                 // need to create a map within the list
                                 let newObjectId = try document.insertObject(
@@ -469,7 +468,7 @@ extension AnyCodingKey {
                                     indent: path.count - 1,
                                     "Created new Map container with ObjectId \(newObjectId)."
                                 )
-                                return .success((newObjectId, AnyCodingKey("")))
+                                return .success(newObjectId)
                             }
                         }
                     }
@@ -501,7 +500,7 @@ extension AnyCodingKey {
                                     //                            EncoderPathCache.upsert(extendedPath, value: (objId,
                                     //                            objType))
                                     tracePrint(indent: path.count - 1, "Found Map container with ObjectId \(objId).")
-                                    return .success((objId, AnyCodingKey("")))
+                                    return .success(objId)
                                 } else {
                                     return .failure(
                                         CodingKeyLookupError
@@ -515,7 +514,7 @@ extension AnyCodingKey {
                                     //                            EncoderPathCache.upsert(extendedPath, value: (objId,
                                     //                            objType))
                                     tracePrint(indent: path.count - 1, "Found List container with ObjectId \(objId).")
-                                    return .success((objId, AnyCodingKey("")))
+                                    return .success(objId)
                                 } else {
                                     return .failure(
                                         CodingKeyLookupError
@@ -558,7 +557,7 @@ extension AnyCodingKey {
                                     indent: path.count - 1,
                                     "Created new List container with ObjectId \(newObjectId)."
                                 )
-                                return .success((newObjectId, AnyCodingKey("")))
+                                return .success(newObjectId)
                             } else {
                                 // need to create a map within the list
                                 let newObjectId = try document.putObject(
@@ -571,7 +570,7 @@ extension AnyCodingKey {
                                     indent: path.count - 1,
                                     "Created new Map container with ObjectId \(newObjectId)."
                                 )
-                                return .success((newObjectId, AnyCodingKey("")))
+                                return .success(newObjectId)
                             }
                         }
                     }
@@ -583,14 +582,14 @@ extension AnyCodingKey {
             if path.count < 2 {
                 // corner case where the root encoder (equivalent to position -1 in the matchingObjectIds) isn't in the
                 // lookup list
-                return .success((ObjId.ROOT, AnyCodingKey(finalpiece)))
+                return .success(ObjId.ROOT)
             } else {
                 guard let containerObjectId = matchingObjectIds[path.count - 2] else {
                     fatalError(
                         "objectId lookups failed to identify an object Id for the last element in path: \(path)"
                     )
                 }
-                return .success((containerObjectId, AnyCodingKey(finalpiece)))
+                return .success(containerObjectId)
             }
         }
     }

--- a/Sources/AutomergeSwiftAdditions/Codable/Decoding/AutomergeDecoderImpl.swift
+++ b/Sources/AutomergeSwiftAdditions/Codable/Decoding/AutomergeDecoderImpl.swift
@@ -45,7 +45,7 @@ extension AutomergeDecoderImpl: Decoder {
             strategy: .readonly
         )
         switch result {
-        case let .success((objectId, _)):
+        case let .success(objectId):
             let objectType = doc.objectType(obj: objectId)
             guard case .Map = objectType else {
                 throw DecodingError.typeMismatch([String: AutomergeValue].self, DecodingError.Context(
@@ -73,7 +73,7 @@ extension AutomergeDecoderImpl: Decoder {
             strategy: .readonly
         )
         switch result {
-        case let .success((objectId, _)):
+        case let .success(objectId):
             let objectType = doc.objectType(obj: objectId)
             guard case .List = objectType else {
                 throw DecodingError.typeMismatch([String: AutomergeValue].self, DecodingError.Context(
@@ -101,8 +101,11 @@ extension AutomergeDecoderImpl: Decoder {
             strategy: .readonly
         )
         switch result {
-        case let .success((objectId, finalKey)):
-
+        case let .success(objectId):
+            guard let finalKey = codingPath.last else {
+                throw CodingKeyLookupError
+                    .noPathForSingleValue("Attempting to establish a single value container with an empty coding path.")
+            }
             let finalAutomergeValue: Value?
             if let indexValue = finalKey.intValue {
                 finalAutomergeValue = try doc.get(obj: objectId, index: UInt64(indexValue))

--- a/Sources/AutomergeSwiftAdditions/Codable/Decoding/AutomergeSingleValueDecodingContainer.swift
+++ b/Sources/AutomergeSwiftAdditions/Codable/Decoding/AutomergeSingleValueDecodingContainer.swift
@@ -180,7 +180,7 @@ struct AutomergeSingleValueDecodingContainer: SingleValueDecodingContainer {
                 strategy: .readonly
             )
             switch result {
-            case let .success((objectId, _)):
+            case let .success(objectId):
                 let type = impl.doc.objectType(obj: objectId)
                 guard type == .Text else {
                     throw DecodingError.dataCorrupted(

--- a/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeEncoder.swift
+++ b/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeEncoder.swift
@@ -5,7 +5,7 @@ public struct AutomergeEncoder {
     var doc: Document
     var schemaStrategy: SchemaStrategy
 
-    public init(doc: Document, strategy: SchemaStrategy = .default) {
+    public init(doc: Document, strategy: SchemaStrategy = .createWhenNeeded) {
         self.doc = doc
         self.schemaStrategy = strategy
     }
@@ -14,7 +14,8 @@ public struct AutomergeEncoder {
         let encoder = AutomergeEncoderImpl(
             userInfo: userInfo,
             codingPath: [],
-            doc: self.doc
+            doc: self.doc,
+            strategy: self.schemaStrategy
         )
         try value.encode(to: encoder)
     }

--- a/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeEncoderImpl.swift
+++ b/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeEncoderImpl.swift
@@ -9,14 +9,16 @@ class AutomergeEncoderImpl {
     let userInfo: [CodingUserInfoKey: Any]
     let codingPath: [CodingKey]
     let document: Document
+    let schemaStrategy: SchemaStrategy
 
     // indicator that the singleValue has written a value
     var singleValueWritten: Bool = false
 
-    init(userInfo: [CodingUserInfoKey: Any], codingPath: [CodingKey], doc: Document) {
+    init(userInfo: [CodingUserInfoKey: Any], codingPath: [CodingKey], doc: Document, strategy: SchemaStrategy) {
         self.userInfo = userInfo
         self.codingPath = codingPath
         self.document = doc
+        self.schemaStrategy = strategy
         // Clear out any cache on setting up with a new document
         self.cache = [:]
     }

--- a/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeKeyedEncodingContainer.swift
+++ b/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeKeyedEncodingContainer.swift
@@ -54,7 +54,7 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
             containerType: .Key,
             strategy: impl.schemaStrategy
         ) {
-        case let .success((objId, _)):
+        case let .success(objId):
             self.objectId = objId
             self.lookupError = nil
         case let .failure(capturedError):

--- a/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeKeyedEncodingContainer.swift
+++ b/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeKeyedEncodingContainer.swift
@@ -48,7 +48,12 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
         self.impl = impl
         self.codingPath = codingPath
         self.document = doc
-        switch AnyCodingKey.retrieveObjectId(document: doc, path: codingPath, containerType: .Key) {
+        switch AnyCodingKey.retrieveObjectId(
+            document: doc,
+            path: codingPath,
+            containerType: .Key,
+            strategy: impl.schemaStrategy
+        ) {
         case let .success((objId, _)):
             self.objectId = objId
             self.lookupError = nil
@@ -225,7 +230,8 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
         let newEncoder = AutomergeEncoderImpl(
             userInfo: impl.userInfo,
             codingPath: newPath,
-            doc: self.document
+            doc: self.document,
+            strategy: impl.schemaStrategy
         )
         switch T.self {
         case is Date.Type:

--- a/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeSingleValueEncodingContainer.swift
+++ b/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeSingleValueEncodingContainer.swift
@@ -28,10 +28,17 @@ struct AutomergeSingleValueEncodingContainer: SingleValueEncodingContainer {
             containerType: .Value,
             strategy: impl.schemaStrategy
         ) {
-        case let .success((objId, codingkey)):
-            self.objectId = objId
-            self.codingkey = codingkey
-            self.lookupError = nil
+        case let .success(objId):
+            if let lastCodingKey = codingPath.last {
+                self.objectId = objId
+                self.codingkey = AnyCodingKey(lastCodingKey)
+                self.lookupError = nil
+            } else {
+                self.objectId = objId
+                self.codingkey = nil
+                self.lookupError = CodingKeyLookupError
+                    .noPathForSingleValue("Attempting to encode a value with an empty coding path.")
+            }
         case let .failure(capturedError):
             self.objectId = nil
             self.codingkey = nil

--- a/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeSingleValueEncodingContainer.swift
+++ b/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeSingleValueEncodingContainer.swift
@@ -22,7 +22,12 @@ struct AutomergeSingleValueEncodingContainer: SingleValueEncodingContainer {
         self.impl = impl
         self.codingPath = codingPath
         self.document = doc
-        switch AnyCodingKey.retrieveObjectId(document: doc, path: codingPath, containerType: .Value) {
+        switch AnyCodingKey.retrieveObjectId(
+            document: doc,
+            path: codingPath,
+            containerType: .Value,
+            strategy: impl.schemaStrategy
+        ) {
         case let .success((objId, codingkey)):
             self.objectId = objId
             self.codingkey = codingkey

--- a/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeUnkeyedEncodingContainer.swift
+++ b/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeUnkeyedEncodingContainer.swift
@@ -30,7 +30,7 @@ struct AutomergeUnkeyedEncodingContainer: UnkeyedEncodingContainer {
             containerType: .Index,
             strategy: impl.schemaStrategy
         ) {
-        case let .success((objId, _)):
+        case let .success(objId):
             self.objectId = objId
             self.lookupError = nil
         case let .failure(capturedError):

--- a/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeUnkeyedEncodingContainer.swift
+++ b/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeUnkeyedEncodingContainer.swift
@@ -24,7 +24,12 @@ struct AutomergeUnkeyedEncodingContainer: UnkeyedEncodingContainer {
         // array = impl.array!
         self.codingPath = codingPath
         self.document = doc
-        switch AnyCodingKey.retrieveObjectId(document: doc, path: codingPath, containerType: .Index) {
+        switch AnyCodingKey.retrieveObjectId(
+            document: doc,
+            path: codingPath,
+            containerType: .Index,
+            strategy: impl.schemaStrategy
+        ) {
         case let .success((objId, _)):
             self.objectId = objId
             self.lookupError = nil
@@ -56,7 +61,8 @@ struct AutomergeUnkeyedEncodingContainer: UnkeyedEncodingContainer {
         let newEncoder = AutomergeEncoderImpl(
             userInfo: impl.userInfo,
             codingPath: newPath,
-            doc: self.document
+            doc: self.document,
+            strategy: impl.schemaStrategy
         )
         guard let objectId = self.objectId else {
             throw reportBestError()

--- a/Sources/AutomergeSwiftAdditions/Codable/SchemaStrategy.swift
+++ b/Sources/AutomergeSwiftAdditions/Codable/SchemaStrategy.swift
@@ -12,7 +12,7 @@ public enum SchemaStrategy {
     /// path
     /// is a leaf-node
     /// (a scalar value, or a Text instance), then the lookup captures the schema error for later presentation.
-    case `default`
+    case createWhenNeeded
 
     /// Creates schema, irregardless of existing schema.
     ///

--- a/Sources/AutomergeSwiftAdditions/Document+Path.swift
+++ b/Sources/AutomergeSwiftAdditions/Document+Path.swift
@@ -28,8 +28,12 @@ extension Document {
             strategy: .readonly
         )
         switch result {
-        case .success(let (objectId, finalCodingKey)):
+        case let .success(objectId):
             let existingValue: Value?
+            guard let finalCodingKey = codingPath.last else {
+                throw CodingKeyLookupError
+                    .noPathForSingleValue("Attempting to establish a single value container with an empty coding path.")
+            }
             // get any existing value - type of the `get` call is based on the key type
             if let indexValue = finalCodingKey.intValue {
                 existingValue = try get(obj: objectId, index: UInt64(indexValue))

--- a/Tests/AutomergeSwiftAdditionsTests/AutomergeEncoderImpl+RetrieveTests.swift
+++ b/Tests/AutomergeSwiftAdditionsTests/AutomergeEncoderImpl+RetrieveTests.swift
@@ -46,7 +46,12 @@ final class RetrieveObjectIdTests: XCTestCase {
             AnyCodingKey("notes"),
         ]
 
-        let result = AnyCodingKey.retrieveObjectId(document: doc, path: fullCodingPath, containerType: .Value)
+        let result = AnyCodingKey.retrieveObjectId(
+            document: doc,
+            path: fullCodingPath,
+            containerType: .Value,
+            strategy: .createWhenNeeded
+        )
 
         switch result {
         case let .success((objectId, codingKeyInstance)):
@@ -65,7 +70,12 @@ final class RetrieveObjectIdTests: XCTestCase {
             AnyCodingKey(1),
         ]
 
-        let result = AnyCodingKey.retrieveObjectId(document: doc, path: newCodingPath, containerType: .Key)
+        let result = AnyCodingKey.retrieveObjectId(
+            document: doc,
+            path: newCodingPath,
+            containerType: .Key,
+            strategy: .createWhenNeeded
+        )
 
         switch result {
         case let .success((objectId, codingKeyInstance)):
@@ -85,7 +95,12 @@ final class RetrieveObjectIdTests: XCTestCase {
             AnyCodingKey("yellowfish"),
         ]
 
-        let result = AnyCodingKey.retrieveObjectId(document: doc, path: newCodingPath, containerType: .Key)
+        let result = AnyCodingKey.retrieveObjectId(
+            document: doc,
+            path: newCodingPath,
+            containerType: .Key,
+            strategy: .createWhenNeeded
+        )
 
         switch result {
         case let .success((objectId, codingKeyInstance)):
@@ -105,7 +120,12 @@ final class RetrieveObjectIdTests: XCTestCase {
             AnyCodingKey(0),
         ]
 
-        let result = AnyCodingKey.retrieveObjectId(document: doc, path: newCodingPath, containerType: .Index)
+        let result = AnyCodingKey.retrieveObjectId(
+            document: doc,
+            path: newCodingPath,
+            containerType: .Index,
+            strategy: .createWhenNeeded
+        )
 
         switch result {
         case let .success((objectId, codingKeyInstance)):
@@ -125,7 +145,12 @@ final class RetrieveObjectIdTests: XCTestCase {
             AnyCodingKey("yellowfish"),
         ]
 
-        let result = AnyCodingKey.retrieveObjectId(document: doc, path: newCodingPath, containerType: .Value)
+        let result = AnyCodingKey.retrieveObjectId(
+            document: doc,
+            path: newCodingPath,
+            containerType: .Value,
+            strategy: .createWhenNeeded
+        )
 
         switch result {
         case let .success((objectId, codingKeyInstance)):
@@ -145,7 +170,12 @@ final class RetrieveObjectIdTests: XCTestCase {
             AnyCodingKey("yellowfish"),
         ]
 
-        let result = AnyCodingKey.retrieveObjectId(document: doc, path: newCodingPath, containerType: .Value)
+        let result = AnyCodingKey.retrieveObjectId(
+            document: doc,
+            path: newCodingPath,
+            containerType: .Value,
+            strategy: .createWhenNeeded
+        )
         switch result {
         case .success:
             XCTFail("Expected this to fail with index 5 in a new array")

--- a/Tests/AutomergeSwiftAdditionsTests/AutomergeEncoderImpl+RetrieveTests.swift
+++ b/Tests/AutomergeSwiftAdditionsTests/AutomergeEncoderImpl+RetrieveTests.swift
@@ -54,9 +54,8 @@ final class RetrieveObjectIdTests: XCTestCase {
         )
 
         switch result {
-        case let .success((objectId, codingKeyInstance)):
+        case let .success(objectId):
             XCTAssertEqual(objectId, setupCache["nestedMap"])
-            XCTAssertEqual(codingKeyInstance, AnyCodingKey("notes"))
         case .failure:
             XCTFail("Failure looking up full path to notes as a value")
         }
@@ -78,8 +77,7 @@ final class RetrieveObjectIdTests: XCTestCase {
         )
 
         switch result {
-        case let .success((objectId, codingKeyInstance)):
-            XCTAssertEqual(codingKeyInstance, AnyCodingKey.ROOT)
+        case let .success(objectId):
             let pathToNewMap = try! doc.path(obj: objectId).stringPath()
             XCTAssertEqual(pathToNewMap, ".list.[1]")
         case let .failure(err):
@@ -103,8 +101,7 @@ final class RetrieveObjectIdTests: XCTestCase {
         )
 
         switch result {
-        case let .success((objectId, codingKeyInstance)):
-            XCTAssertEqual(codingKeyInstance, AnyCodingKey.ROOT)
+        case let .success(objectId):
             let pathToNewMap = try! doc.path(obj: objectId).stringPath()
             XCTAssertEqual(pathToNewMap, ".redfish.[0].bluefish.yellowfish")
         case let .failure(err):
@@ -128,8 +125,7 @@ final class RetrieveObjectIdTests: XCTestCase {
         )
 
         switch result {
-        case let .success((objectId, codingKeyInstance)):
-            XCTAssertEqual(codingKeyInstance, AnyCodingKey.ROOT)
+        case let .success(objectId):
             let pathToNewMap = try! doc.path(obj: objectId).stringPath()
             XCTAssertEqual(pathToNewMap, ".redfish.[0].bluefish.[0]")
         case let .failure(err):
@@ -153,8 +149,7 @@ final class RetrieveObjectIdTests: XCTestCase {
         )
 
         switch result {
-        case let .success((objectId, codingKeyInstance)):
-            XCTAssertEqual(codingKeyInstance.stringValue, "yellowfish")
+        case let .success(objectId):
             let pathToNewMap = try! doc.path(obj: objectId).stringPath()
             XCTAssertEqual(pathToNewMap, ".redfish.[0].bluefish")
         case let .failure(err):


### PR DESCRIPTION
more fixes - refactoring retrieve function to return only an objectId on success path, and matching logic to retrieve the path from the codingPath at call sites instead.