### PR TITLE
Cautious write

### DIFF
--- a/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeEncoder.swift
+++ b/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeEncoder.swift
@@ -4,10 +4,12 @@ public struct AutomergeEncoder {
     public var userInfo: [CodingUserInfoKey: Any] = [:]
     var doc: Document
     var schemaStrategy: SchemaStrategy
+    var cautiousWrite: Bool
 
-    public init(doc: Document, strategy: SchemaStrategy = .createWhenNeeded) {
+    public init(doc: Document, strategy: SchemaStrategy = .createWhenNeeded, cautiousWrite: Bool = false) {
         self.doc = doc
         self.schemaStrategy = strategy
+        self.cautiousWrite = cautiousWrite
     }
 
     public func encode<T: Encodable>(_ value: T?) throws {
@@ -23,7 +25,8 @@ public struct AutomergeEncoder {
             userInfo: userInfo,
             codingPath: [],
             doc: self.doc,
-            strategy: self.schemaStrategy
+            strategy: self.schemaStrategy,
+            cautiousWrite: self.cautiousWrite
         )
         try value.encode(to: encoder)
     }
@@ -33,7 +36,8 @@ public struct AutomergeEncoder {
             userInfo: userInfo,
             codingPath: path,
             doc: self.doc,
-            strategy: self.schemaStrategy
+            strategy: self.schemaStrategy,
+            cautiousWrite: self.cautiousWrite
         )
         try value.encode(to: encoder)
     }

--- a/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeEncoderImpl.swift
+++ b/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeEncoderImpl.swift
@@ -5,20 +5,28 @@ import struct Automerge.ObjId
 ///
 /// Instances of the class capture one of the various kinds of schema value types - single value, array, or object.
 /// The instance also tracks the dynamic state associated with that value as it encodes types you provide.
-class AutomergeEncoderImpl {
+final class AutomergeEncoderImpl {
     let userInfo: [CodingUserInfoKey: Any]
     let codingPath: [CodingKey]
     let document: Document
     let schemaStrategy: SchemaStrategy
+    let cautiousWrite: Bool
 
     // indicator that the singleValue has written a value
     var singleValueWritten: Bool = false
 
-    init(userInfo: [CodingUserInfoKey: Any], codingPath: [CodingKey], doc: Document, strategy: SchemaStrategy) {
+    init(
+        userInfo: [CodingUserInfoKey: Any],
+        codingPath: [CodingKey],
+        doc: Document,
+        strategy: SchemaStrategy,
+        cautiousWrite: Bool
+    ) {
         self.userInfo = userInfo
         self.codingPath = codingPath
         self.document = doc
         self.schemaStrategy = strategy
+        self.cautiousWrite = cautiousWrite
     }
 }
 

--- a/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeKeyedEncodingContainer.swift
+++ b/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeKeyedEncodingContainer.swift
@@ -80,6 +80,22 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
         }
     }
 
+    fileprivate func checkTypeMatch<T>(value: T, objectId: ObjId, key: Self.Key, type _: TypeOfAutomergeValue) throws {
+        if let testCurrentValue = try document.get(obj: objectId, key: key.stringValue),
+           TypeOfAutomergeValue.from(testCurrentValue) != .string
+        {
+            // BLOW UP HERE
+            throw EncodingError.invalidValue(
+                value,
+                EncodingError
+                    .Context(
+                        codingPath: codingPath,
+                        debugDescription: "The type in the automerge document (\(TypeOfAutomergeValue.from(testCurrentValue))) doesn't match the type being written (\(TypeOfAutomergeValue.string))"
+                    )
+            )
+        }
+    }
+
     mutating func encodeNil(forKey key: Self.Key) throws {
         guard let objectId = self.objectId else {
             throw reportBestError()
@@ -91,12 +107,18 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
         guard let objectId = self.objectId else {
             throw reportBestError()
         }
+        if impl.cautiousWrite {
+            try checkTypeMatch(value: value, objectId: objectId, key: key, type: .bool)
+        }
         try document.put(obj: objectId, key: key.stringValue, value: .Boolean(value))
     }
 
     mutating func encode(_ value: String, forKey key: Self.Key) throws {
         guard let objectId = self.objectId else {
             throw reportBestError()
+        }
+        if impl.cautiousWrite {
+            try checkTypeMatch(value: value, objectId: objectId, key: key, type: .string)
         }
         try document.put(obj: objectId, key: key.stringValue, value: .String(value))
     }
@@ -111,6 +133,9 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
                 debugDescription: "Unable to encode Double.\(value) at \(codingPath) into an Automerge F64."
             ))
         }
+        if impl.cautiousWrite {
+            try checkTypeMatch(value: value, objectId: objectId, key: key, type: .double)
+        }
         try document.put(obj: objectId, key: key.stringValue, value: value.toScalarValue())
     }
 
@@ -124,6 +149,9 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
                 debugDescription: "Unable to encode Float.\(value) directly in JSON."
             ))
         }
+        if impl.cautiousWrite {
+            try checkTypeMatch(value: value, objectId: objectId, key: key, type: .double)
+        }
         try document.put(obj: objectId, key: key.stringValue, value: value.toScalarValue())
     }
 
@@ -131,7 +159,9 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
         guard let objectId = self.objectId else {
             throw reportBestError()
         }
-
+        if impl.cautiousWrite {
+            try checkTypeMatch(value: value, objectId: objectId, key: key, type: .int)
+        }
         try document.put(obj: objectId, key: key.stringValue, value: value.toScalarValue())
     }
 
@@ -139,7 +169,9 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
         guard let objectId = objectId else {
             throw reportBestError()
         }
-
+        if impl.cautiousWrite {
+            try checkTypeMatch(value: value, objectId: objectId, key: key, type: .int)
+        }
         try document.put(obj: objectId, key: key.stringValue, value: value.toScalarValue())
     }
 
@@ -147,7 +179,9 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
         guard let objectId = objectId else {
             throw reportBestError()
         }
-
+        if impl.cautiousWrite {
+            try checkTypeMatch(value: value, objectId: objectId, key: key, type: .int)
+        }
         try document.put(obj: objectId, key: key.stringValue, value: value.toScalarValue())
     }
 
@@ -155,7 +189,9 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
         guard let objectId = objectId else {
             throw reportBestError()
         }
-
+        if impl.cautiousWrite {
+            try checkTypeMatch(value: value, objectId: objectId, key: key, type: .int)
+        }
         try document.put(obj: objectId, key: key.stringValue, value: value.toScalarValue())
     }
 
@@ -163,7 +199,9 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
         guard let objectId = self.objectId else {
             throw reportBestError()
         }
-
+        if impl.cautiousWrite {
+            try checkTypeMatch(value: value, objectId: objectId, key: key, type: .int)
+        }
         try document.put(obj: objectId, key: key.stringValue, value: value.toScalarValue())
     }
 
@@ -171,7 +209,9 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
         guard let objectId = self.objectId else {
             throw reportBestError()
         }
-
+        if impl.cautiousWrite {
+            try checkTypeMatch(value: value, objectId: objectId, key: key, type: .uint)
+        }
         try document.put(obj: objectId, key: key.stringValue, value: value.toScalarValue())
     }
 
@@ -179,7 +219,9 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
         guard let objectId = self.objectId else {
             throw reportBestError()
         }
-
+        if impl.cautiousWrite {
+            try checkTypeMatch(value: value, objectId: objectId, key: key, type: .uint)
+        }
         try document.put(obj: objectId, key: key.stringValue, value: value.toScalarValue())
     }
 
@@ -187,7 +229,9 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
         guard let objectId = objectId else {
             throw reportBestError()
         }
-
+        if impl.cautiousWrite {
+            try checkTypeMatch(value: value, objectId: objectId, key: key, type: .uint)
+        }
         try document.put(obj: objectId, key: key.stringValue, value: value.toScalarValue())
     }
 
@@ -195,7 +239,9 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
         guard let objectId = self.objectId else {
             throw reportBestError()
         }
-
+        if impl.cautiousWrite {
+            try checkTypeMatch(value: value, objectId: objectId, key: key, type: .uint)
+        }
         try document.put(obj: objectId, key: key.stringValue, value: value.toScalarValue())
     }
 
@@ -203,7 +249,9 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
         guard let objectId = objectId else {
             throw reportBestError()
         }
-
+        if impl.cautiousWrite {
+            try checkTypeMatch(value: value, objectId: objectId, key: key, type: .uint)
+        }
         try document.put(obj: objectId, key: key.stringValue, value: value.toScalarValue())
     }
 
@@ -241,16 +289,25 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
             // Capture and override the default encodable pathing for Date since
             // Automerge supports it as a primitive value type.
             let downcastDate = value as! Date
+            if impl.cautiousWrite {
+                try checkTypeMatch(value: value, objectId: objectId, key: key, type: .timestamp)
+            }
             try document.put(obj: objectId, key: key.stringValue, value: downcastDate.toScalarValue())
         case is Data.Type:
             // Capture and override the default encodable pathing for Data since
             // Automerge supports it as a primitive value type.
             let downcastData = value as! Data
+            if impl.cautiousWrite {
+                try checkTypeMatch(value: value, objectId: objectId, key: key, type: .bytes)
+            }
             try document.put(obj: objectId, key: key.stringValue, value: downcastData.toScalarValue())
         case is Counter.Type:
             // Capture and override the default encodable pathing for Counter since
             // Automerge supports it as a primitive value type.
             let downcastCounter = value as! Counter
+            if impl.cautiousWrite {
+                try checkTypeMatch(value: value, objectId: objectId, key: key, type: .counter)
+            }
             try document.put(obj: objectId, key: key.stringValue, value: downcastCounter.toScalarValue())
         case is Text.Type:
             // Capture and override the default encodable pathing for Counter since

--- a/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeKeyedEncodingContainer.swift
+++ b/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeKeyedEncodingContainer.swift
@@ -233,7 +233,8 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
             userInfo: impl.userInfo,
             codingPath: newPath,
             doc: self.document,
-            strategy: impl.schemaStrategy
+            strategy: impl.schemaStrategy,
+            cautiousWrite: impl.cautiousWrite
         )
         switch T.self {
         case is Date.Type:

--- a/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeKeyedEncodingContainer.swift
+++ b/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeKeyedEncodingContainer.swift
@@ -80,9 +80,9 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
         }
     }
 
-    fileprivate func checkTypeMatch<T>(value: T, objectId: ObjId, key: Self.Key, type _: TypeOfAutomergeValue) throws {
+    fileprivate func checkTypeMatch<T>(value: T, objectId: ObjId, key: Self.Key, type: TypeOfAutomergeValue) throws {
         if let testCurrentValue = try document.get(obj: objectId, key: key.stringValue),
-           TypeOfAutomergeValue.from(testCurrentValue) != .string
+           TypeOfAutomergeValue.from(testCurrentValue) != type
         {
             // BLOW UP HERE
             throw EncodingError.invalidValue(
@@ -90,7 +90,7 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
                 EncodingError
                     .Context(
                         codingPath: codingPath,
-                        debugDescription: "The type in the automerge document (\(TypeOfAutomergeValue.from(testCurrentValue))) doesn't match the type being written (\(TypeOfAutomergeValue.string))"
+                        debugDescription: "The type in the automerge document (\(TypeOfAutomergeValue.from(testCurrentValue))) doesn't match the type being written (\(type))"
                     )
             )
         }

--- a/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeSingleValueEncodingContainer.swift
+++ b/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeSingleValueEncodingContainer.swift
@@ -151,10 +151,37 @@ struct AutomergeSingleValueEncodingContainer: SingleValueEncodingContainer {
                         "No coding key was found from looking up path \(codingPath) when encoding \(type(of: T.self))."
                     )
             }
+            let valueToWrite = downcastDate.toScalarValue()
             if let indexToWrite = codingkey.intValue {
-                try document.insert(obj: objectId, index: UInt64(indexToWrite), value: downcastDate.toScalarValue())
+                if let testCurrentValue = try document.get(obj: objectId, index: UInt64(indexToWrite)),
+                   TypeOfAutomergeValue.from(testCurrentValue) != TypeOfAutomergeValue.from(valueToWrite)
+                {
+                    // BLOW UP HERE
+                    throw EncodingError.invalidValue(
+                        value,
+                        EncodingError
+                            .Context(
+                                codingPath: codingPath,
+                                debugDescription: "The type in the automerge document (\(TypeOfAutomergeValue.from(testCurrentValue))) doesn't match the type being written (\(TypeOfAutomergeValue.from(valueToWrite)))"
+                            )
+                    )
+                }
+                try document.insert(obj: objectId, index: UInt64(indexToWrite), value: valueToWrite)
             } else {
-                try document.put(obj: objectId, key: codingkey.stringValue, value: downcastDate.toScalarValue())
+                if let testCurrentValue = try document.get(obj: objectId, key: codingkey.stringValue),
+                   TypeOfAutomergeValue.from(testCurrentValue) != TypeOfAutomergeValue.from(valueToWrite)
+                {
+                    // BLOW UP HERE
+                    throw EncodingError.invalidValue(
+                        value,
+                        EncodingError
+                            .Context(
+                                codingPath: codingPath,
+                                debugDescription: "The type in the automerge document (\(TypeOfAutomergeValue.from(testCurrentValue))) doesn't match the type being written (\(TypeOfAutomergeValue.from(valueToWrite)))"
+                            )
+                    )
+                }
+                try document.put(obj: objectId, key: codingkey.stringValue, value: valueToWrite)
             }
         case is Data.Type:
             // Capture and override the default encodable pathing for Data since
@@ -166,10 +193,43 @@ struct AutomergeSingleValueEncodingContainer: SingleValueEncodingContainer {
                         "No coding key was found from looking up path \(codingPath) when encoding \(type(of: T.self))."
                     )
             }
+            let valueToWrite = downcastData.toScalarValue()
             if let indexToWrite = codingkey.intValue {
-                try document.insert(obj: objectId, index: UInt64(indexToWrite), value: downcastData.toScalarValue())
+                if impl.cautiousWrite {
+                    if let testCurrentValue = try document.get(obj: objectId, index: UInt64(indexToWrite)),
+                       TypeOfAutomergeValue.from(testCurrentValue) != TypeOfAutomergeValue.from(valueToWrite)
+                    {
+                        // BLOW UP HERE
+                        throw EncodingError.invalidValue(
+                            value,
+                            EncodingError
+                                .Context(
+                                    codingPath: codingPath,
+                                    debugDescription: "The type in the automerge document (\(TypeOfAutomergeValue.from(testCurrentValue))) doesn't match the type being written (\(TypeOfAutomergeValue.from(valueToWrite)))"
+                                )
+                        )
+                    }
+                }
+
+                try document.insert(obj: objectId, index: UInt64(indexToWrite), value: valueToWrite)
             } else {
-                try document.put(obj: objectId, key: codingkey.stringValue, value: downcastData.toScalarValue())
+                if impl.cautiousWrite {
+                    if let testCurrentValue = try document.get(obj: objectId, key: codingkey.stringValue),
+                       TypeOfAutomergeValue.from(testCurrentValue) != TypeOfAutomergeValue.from(valueToWrite)
+                    {
+                        // BLOW UP HERE
+                        throw EncodingError.invalidValue(
+                            value,
+                            EncodingError
+                                .Context(
+                                    codingPath: codingPath,
+                                    debugDescription: "The type in the automerge document (\(TypeOfAutomergeValue.from(testCurrentValue))) doesn't match the type being written (\(TypeOfAutomergeValue.from(valueToWrite)))"
+                                )
+                        )
+                    }
+                }
+
+                try document.put(obj: objectId, key: codingkey.stringValue, value: valueToWrite)
             }
         case is Counter.Type:
             // Capture and override the default encodable pathing for Counter since
@@ -181,10 +241,41 @@ struct AutomergeSingleValueEncodingContainer: SingleValueEncodingContainer {
                         "No coding key was found from looking up path \(codingPath) when encoding \(type(of: T.self))."
                     )
             }
+            let valueToWrite = downcastCounter.toScalarValue()
             if let indexToWrite = codingkey.intValue {
-                try document.insert(obj: objectId, index: UInt64(indexToWrite), value: downcastCounter.toScalarValue())
+                if impl.cautiousWrite {
+                    if let testCurrentValue = try document.get(obj: objectId, index: UInt64(indexToWrite)),
+                       TypeOfAutomergeValue.from(testCurrentValue) != TypeOfAutomergeValue.from(valueToWrite)
+                    {
+                        // BLOW UP HERE
+                        throw EncodingError.invalidValue(
+                            value,
+                            EncodingError
+                                .Context(
+                                    codingPath: codingPath,
+                                    debugDescription: "The type in the automerge document (\(TypeOfAutomergeValue.from(testCurrentValue))) doesn't match the type being written (\(TypeOfAutomergeValue.from(valueToWrite)))"
+                                )
+                        )
+                    }
+                }
+                try document.insert(obj: objectId, index: UInt64(indexToWrite), value: valueToWrite)
             } else {
-                try document.put(obj: objectId, key: codingkey.stringValue, value: downcastCounter.toScalarValue())
+                if impl.cautiousWrite {
+                    if let testCurrentValue = try document.get(obj: objectId, key: codingkey.stringValue),
+                       TypeOfAutomergeValue.from(testCurrentValue) != TypeOfAutomergeValue.from(valueToWrite)
+                    {
+                        // BLOW UP HERE
+                        throw EncodingError.invalidValue(
+                            value,
+                            EncodingError
+                                .Context(
+                                    codingPath: codingPath,
+                                    debugDescription: "The type in the automerge document (\(TypeOfAutomergeValue.from(testCurrentValue))) doesn't match the type being written (\(TypeOfAutomergeValue.from(valueToWrite)))"
+                                )
+                        )
+                    }
+                }
+                try document.put(obj: objectId, key: codingkey.stringValue, value: valueToWrite)
             }
         case is Text.Type:
             guard let codingkey = codingkey else {
@@ -247,10 +338,41 @@ struct AutomergeSingleValueEncodingContainer: SingleValueEncodingContainer {
         guard let objectId = self.objectId, let codingkey = self.codingkey else {
             throw reportBestError()
         }
+        let valueToWrite = value.toScalarValue()
         if let indexToWrite = codingkey.intValue {
-            try document.insert(obj: objectId, index: UInt64(indexToWrite), value: value.toScalarValue())
+            if impl.cautiousWrite {
+                if let testCurrentValue = try document.get(obj: objectId, index: UInt64(indexToWrite)),
+                   TypeOfAutomergeValue.from(testCurrentValue) != TypeOfAutomergeValue.from(valueToWrite)
+                {
+                    // BLOW UP HERE
+                    throw EncodingError.invalidValue(
+                        value,
+                        EncodingError
+                            .Context(
+                                codingPath: codingPath,
+                                debugDescription: "The type in the automerge document (\(TypeOfAutomergeValue.from(testCurrentValue))) doesn't match the type being written (\(TypeOfAutomergeValue.from(valueToWrite)))"
+                            )
+                    )
+                }
+            }
+            try document.insert(obj: objectId, index: UInt64(indexToWrite), value: valueToWrite)
         } else {
-            try document.put(obj: objectId, key: codingkey.stringValue, value: value.toScalarValue())
+            if impl.cautiousWrite {
+                if let testCurrentValue = try document.get(obj: objectId, key: codingkey.stringValue),
+                   TypeOfAutomergeValue.from(testCurrentValue) != TypeOfAutomergeValue.from(valueToWrite)
+                {
+                    // BLOW UP HERE
+                    throw EncodingError.invalidValue(
+                        value,
+                        EncodingError
+                            .Context(
+                                codingPath: codingPath,
+                                debugDescription: "The type in the automerge document (\(TypeOfAutomergeValue.from(testCurrentValue))) doesn't match the type being written (\(TypeOfAutomergeValue.from(valueToWrite)))"
+                            )
+                    )
+                }
+            }
+            try document.put(obj: objectId, key: codingkey.stringValue, value: valueToWrite)
         }
     }
 

--- a/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeUnkeyedEncodingContainer.swift
+++ b/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeUnkeyedEncodingContainer.swift
@@ -76,17 +76,60 @@ struct AutomergeUnkeyedEncodingContainer: UnkeyedEncodingContainer {
             // Capture and override the default encodable pathing for Date since
             // Automerge supports it as a primitive value type.
             let downcastDate = value as! Date
-            try self.document.insert(obj: objectId, index: UInt64(count), value: downcastDate.toScalarValue())
+            let valueToWrite = downcastDate.toScalarValue()
+            if let testCurrentValue = try document.get(obj: objectId, index: UInt64(count)),
+               TypeOfAutomergeValue.from(testCurrentValue) != TypeOfAutomergeValue.from(valueToWrite)
+            {
+                // BLOW UP HERE
+                throw EncodingError.invalidValue(
+                    value,
+                    EncodingError
+                        .Context(
+                            codingPath: codingPath,
+                            debugDescription: "The type in the automerge document (\(TypeOfAutomergeValue.from(testCurrentValue))) doesn't match the type being written (\(TypeOfAutomergeValue.from(valueToWrite)))"
+                        )
+                )
+            }
+            try self.document.insert(obj: objectId, index: UInt64(count), value: valueToWrite)
         case is Data.Type:
             // Capture and override the default encodable pathing for Data since
             // Automerge supports it as a primitive value type.
             let downcastData = value as! Data
-            try self.document.insert(obj: objectId, index: UInt64(count), value: downcastData.toScalarValue())
+            let valueToWrite = downcastData.toScalarValue()
+            if let testCurrentValue = try document.get(obj: objectId, index: UInt64(count)),
+               TypeOfAutomergeValue.from(testCurrentValue) != TypeOfAutomergeValue.from(valueToWrite)
+            {
+                // BLOW UP HERE
+                throw EncodingError.invalidValue(
+                    value,
+                    EncodingError
+                        .Context(
+                            codingPath: codingPath,
+                            debugDescription: "The type in the automerge document (\(TypeOfAutomergeValue.from(testCurrentValue))) doesn't match the type being written (\(TypeOfAutomergeValue.from(valueToWrite)))"
+                        )
+                )
+            }
+
+            try self.document.insert(obj: objectId, index: UInt64(count), value: valueToWrite)
         case is Counter.Type:
             // Capture and override the default encodable pathing for Counter since
             // Automerge supports it as a primitive value type.
             let downcastCounter = value as! Counter
-            try self.document.insert(obj: objectId, index: UInt64(count), value: downcastCounter.toScalarValue())
+            let valueToWrite = downcastCounter.toScalarValue()
+            if let testCurrentValue = try document.get(obj: objectId, index: UInt64(count)),
+               TypeOfAutomergeValue.from(testCurrentValue) != TypeOfAutomergeValue.from(valueToWrite)
+            {
+                // BLOW UP HERE
+                throw EncodingError.invalidValue(
+                    value,
+                    EncodingError
+                        .Context(
+                            codingPath: codingPath,
+                            debugDescription: "The type in the automerge document (\(TypeOfAutomergeValue.from(testCurrentValue))) doesn't match the type being written (\(TypeOfAutomergeValue.from(valueToWrite)))"
+                        )
+                )
+            }
+            try self.document.insert(obj: objectId, index: UInt64(count), value: valueToWrite)
         case is Text.Type:
             // Capture and override the default encodable pathing for Counter since
             // Automerge supports it as a primitive value type.

--- a/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeUnkeyedEncodingContainer.swift
+++ b/Sources/AutomergeSwiftAdditions/Codable/Encoding/AutomergeUnkeyedEncodingContainer.swift
@@ -64,7 +64,8 @@ struct AutomergeUnkeyedEncodingContainer: UnkeyedEncodingContainer {
             userInfo: impl.userInfo,
             codingPath: newPath,
             doc: self.document,
-            strategy: impl.schemaStrategy
+            strategy: impl.schemaStrategy,
+            cautiousWrite: impl.cautiousWrite
         )
         guard let objectId = self.objectId else {
             throw reportBestError()

--- a/Sources/AutomergeSwiftAdditions/Codable/SchemaStrategy.swift
+++ b/Sources/AutomergeSwiftAdditions/Codable/SchemaStrategy.swift
@@ -2,8 +2,6 @@
 /// as
 /// compared to expected encoding.
 public enum SchemaStrategy {
-    // What we do while looking up if there's a schema mismatch:
-
     /// Creates schema where none exists, errors on schema mismatch.
     ///
     /// Basic schema checking for containers that creates relevant objects in Automerge at the relevant path doesn't

--- a/Sources/AutomergeSwiftAdditions/Codable/TypeOfAutomergeValue.swift
+++ b/Sources/AutomergeSwiftAdditions/Codable/TypeOfAutomergeValue.swift
@@ -1,0 +1,93 @@
+import enum Automerge.ScalarValue
+import enum Automerge.Value
+
+public enum TypeOfAutomergeValue: Equatable, Hashable {
+    /// A list CRDT.
+    case array
+    /// A map CRDT.
+    case object
+    /// A specialized list CRDT for representing text.
+    case text
+    /// A byte buffer.
+    case bytes
+    /// A string.
+    case string
+    /// An unsigned integer.
+    case uint
+    /// A signed integer.
+    case int
+    /// A floating point number.
+    case double
+    /// An integer counter.
+    case counter
+    /// A timestamp represented by the milliseconds since UNIX epoch.
+    case timestamp
+    /// A Boolean value.
+    case bool
+    /// Nil.
+    case unknown(UInt8)
+    /// Nil.
+    case null
+
+    public static func from(_ val: Value) -> Self {
+        switch val {
+        case let .Object(_, objType):
+            switch objType {
+            case .List:
+                return .array
+            case .Map:
+                return .object
+            case .Text:
+                return .text
+            }
+        case let .Scalar(scalarValue):
+            switch scalarValue {
+            case .Boolean:
+                return .bool
+            case .Bytes:
+                return .bytes
+            case .String:
+                return .string
+            case .Uint:
+                return .uint
+            case .Int:
+                return .int
+            case .F64:
+                return .double
+            case .Counter:
+                return .counter
+            case .Timestamp:
+                return .timestamp
+            case let .Unknown(type, _):
+                return .unknown(type)
+            case .Null:
+                return .null
+            }
+        }
+    }
+
+    public static func from(_ val: ScalarValue) -> Self {
+        switch val {
+        case .Boolean:
+            return .bool
+        case .Bytes:
+            return .bytes
+        case .String:
+            return .string
+        case .Uint:
+            return .uint
+        case .Int:
+            return .int
+        case .F64:
+            return .double
+        case .Counter:
+            return .counter
+        case .Timestamp:
+            return .timestamp
+        case let .Unknown(type, _):
+            return .unknown(type)
+        case .Null:
+            return .null
+        }
+    }
+}

--- a/Tests/AutomergeSwiftAdditionsTests/AutomergeDecoderTests.swift
+++ b/Tests/AutomergeSwiftAdditionsTests/AutomergeDecoderTests.swift
@@ -1,10 +1,3 @@
-//
-//  AutomergeEncoderImpl+RetrieveTests.swift
-//  AMTravelNotesTests
-//
-//  Created by Joseph Heck on 5/16/23.
-//
-
 import Automerge
 import AutomergeSwiftAdditions
 import XCTest

--- a/Tests/AutomergeSwiftAdditionsTests/AutomergeKeyEncoderImplTests.swift
+++ b/Tests/AutomergeSwiftAdditionsTests/AutomergeKeyEncoderImplTests.swift
@@ -22,7 +22,8 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
             userInfo: [:],
             codingPath: [],
             doc: doc,
-            strategy: .createWhenNeeded
+            strategy: .createWhenNeeded,
+            cautiousWrite: false
         )
         rootKeyedContainer = impl.container(keyedBy: SampleCodingKeys.self)
     }
@@ -46,7 +47,8 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
             userInfo: [:],
             codingPath: [AnyCodingKey("nothere")],
             doc: doc,
-            strategy: .readonly
+            strategy: .readonly,
+            cautiousWrite: false
         )
         rootKeyedContainer = impl.container(keyedBy: SampleCodingKeys.self)
         XCTAssertThrowsError(try rootKeyedContainer.encode(Float(3.4), forKey: .value))
@@ -120,7 +122,8 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
             userInfo: [:],
             codingPath: [AnyCodingKey("nothere")],
             doc: doc,
-            strategy: .readonly
+            strategy: .readonly,
+            cautiousWrite: false
         )
         rootKeyedContainer = impl.container(keyedBy: SampleCodingKeys.self)
         XCTAssertThrowsError(try rootKeyedContainer.encode(true, forKey: .value))
@@ -131,7 +134,8 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
             userInfo: [:],
             codingPath: [AnyCodingKey("nothere")],
             doc: doc,
-            strategy: .readonly
+            strategy: .readonly,
+            cautiousWrite: false
         )
         rootKeyedContainer = impl.container(keyedBy: SampleCodingKeys.self)
         XCTAssertThrowsError(try rootKeyedContainer.encode(Double(8.16), forKey: .value))
@@ -142,7 +146,8 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
             userInfo: [:],
             codingPath: [AnyCodingKey("nothere")],
             doc: doc,
-            strategy: .readonly
+            strategy: .readonly,
+            cautiousWrite: false
         )
         rootKeyedContainer = impl.container(keyedBy: SampleCodingKeys.self)
         XCTAssertThrowsError(try rootKeyedContainer.encode(Int(8), forKey: .value))
@@ -153,7 +158,8 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
             userInfo: [:],
             codingPath: [AnyCodingKey("nothere")],
             doc: doc,
-            strategy: .readonly
+            strategy: .readonly,
+            cautiousWrite: false
         )
         rootKeyedContainer = impl.container(keyedBy: SampleCodingKeys.self)
         XCTAssertThrowsError(try rootKeyedContainer.encode(Int8(8), forKey: .value))
@@ -164,7 +170,8 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
             userInfo: [:],
             codingPath: [AnyCodingKey("nothere")],
             doc: doc,
-            strategy: .readonly
+            strategy: .readonly,
+            cautiousWrite: false
         )
         rootKeyedContainer = impl.container(keyedBy: SampleCodingKeys.self)
         XCTAssertThrowsError(try rootKeyedContainer.encode(Int16(8), forKey: .value))
@@ -175,7 +182,8 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
             userInfo: [:],
             codingPath: [AnyCodingKey("nothere")],
             doc: doc,
-            strategy: .readonly
+            strategy: .readonly,
+            cautiousWrite: false
         )
         rootKeyedContainer = impl.container(keyedBy: SampleCodingKeys.self)
         XCTAssertThrowsError(try rootKeyedContainer.encode(Int32(8), forKey: .value))
@@ -186,7 +194,8 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
             userInfo: [:],
             codingPath: [AnyCodingKey("nothere")],
             doc: doc,
-            strategy: .readonly
+            strategy: .readonly,
+            cautiousWrite: false
         )
         rootKeyedContainer = impl.container(keyedBy: SampleCodingKeys.self)
         XCTAssertThrowsError(try rootKeyedContainer.encode(Int64(8), forKey: .value))
@@ -197,7 +206,8 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
             userInfo: [:],
             codingPath: [AnyCodingKey("nothere")],
             doc: doc,
-            strategy: .readonly
+            strategy: .readonly,
+            cautiousWrite: false
         )
         rootKeyedContainer = impl.container(keyedBy: SampleCodingKeys.self)
         XCTAssertThrowsError(try rootKeyedContainer.encode(UInt(8), forKey: .value))
@@ -208,7 +218,8 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
             userInfo: [:],
             codingPath: [AnyCodingKey("nothere")],
             doc: doc,
-            strategy: .readonly
+            strategy: .readonly,
+            cautiousWrite: false
         )
         rootKeyedContainer = impl.container(keyedBy: SampleCodingKeys.self)
         XCTAssertThrowsError(try rootKeyedContainer.encode(UInt8(8), forKey: .value))
@@ -219,7 +230,8 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
             userInfo: [:],
             codingPath: [AnyCodingKey("nothere")],
             doc: doc,
-            strategy: .readonly
+            strategy: .readonly,
+            cautiousWrite: false
         )
         rootKeyedContainer = impl.container(keyedBy: SampleCodingKeys.self)
         XCTAssertThrowsError(try rootKeyedContainer.encode(UInt16(8), forKey: .value))
@@ -230,7 +242,8 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
             userInfo: [:],
             codingPath: [AnyCodingKey("nothere")],
             doc: doc,
-            strategy: .readonly
+            strategy: .readonly,
+            cautiousWrite: false
         )
         rootKeyedContainer = impl.container(keyedBy: SampleCodingKeys.self)
         XCTAssertThrowsError(try rootKeyedContainer.encode(UInt32(8), forKey: .value))
@@ -241,7 +254,8 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
             userInfo: [:],
             codingPath: [AnyCodingKey("nothere")],
             doc: doc,
-            strategy: .readonly
+            strategy: .readonly,
+            cautiousWrite: false
         )
         rootKeyedContainer = impl.container(keyedBy: SampleCodingKeys.self)
         XCTAssertThrowsError(try rootKeyedContainer.encode(UInt64(8), forKey: .value))
@@ -256,7 +270,8 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
             userInfo: [:],
             codingPath: [AnyCodingKey("nothere")],
             doc: doc,
-            strategy: .readonly
+            strategy: .readonly,
+            cautiousWrite: false
         )
         rootKeyedContainer = impl.container(keyedBy: SampleCodingKeys.self)
         XCTAssertThrowsError(try rootKeyedContainer.encode(SimpleStruct(a: "foo"), forKey: .value))

--- a/Tests/AutomergeSwiftAdditionsTests/AutomergeKeyEncoderImplTests.swift
+++ b/Tests/AutomergeSwiftAdditionsTests/AutomergeKeyEncoderImplTests.swift
@@ -12,6 +12,8 @@ import XCTest
 final class AutomergeKeyEncoderImplTests: XCTestCase {
     var doc: Document!
     var rootKeyedContainer: KeyedEncodingContainer<AutomergeKeyEncoderImplTests.SampleCodingKeys>!
+    var cautiousKeyedContainer: KeyedEncodingContainer<AutomergeKeyEncoderImplTests.SampleCodingKeys>!
+
     enum SampleCodingKeys: String, CodingKey {
         case value
     }
@@ -26,11 +28,30 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
             cautiousWrite: false
         )
         rootKeyedContainer = impl.container(keyedBy: SampleCodingKeys.self)
+
+        let cautious = AutomergeEncoderImpl(
+            userInfo: [:],
+            codingPath: [],
+            doc: doc,
+            strategy: .createWhenNeeded,
+            cautiousWrite: true
+        )
+        cautiousKeyedContainer = cautious.container(keyedBy: SampleCodingKeys.self)
     }
 
     func testSimpleKeyEncode_Bool() throws {
         try rootKeyedContainer.encode(true, forKey: .value)
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Boolean(true)))
+
+        try cautiousKeyedContainer.encode(false, forKey: .value)
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Boolean(false)))
+    }
+
+    func testSimpleKeyEncode_Bool_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .Int(4))
+        XCTAssertThrowsError(
+            try cautiousKeyedContainer.encode(false, forKey: .value)
+        )
     }
 
     func testSimpleKeyEncode_Float() throws {
@@ -66,9 +87,26 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
         )
     }
 
+    func testSimpleKeyEncode_Float_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .Int(4))
+        XCTAssertThrowsError(
+            try cautiousKeyedContainer.encode(Float(4.0), forKey: .value)
+        )
+        XCTAssertThrowsError(
+            try cautiousKeyedContainer.encode(Double(4.0), forKey: .value)
+        )
+    }
+
     func testSimpleKeyEncode_Int8() throws {
         try rootKeyedContainer.encode(Int8(4), forKey: .value)
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(4)))
+    }
+
+    func testSimpleKeyEncode_Int8_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .F64(4.0))
+        XCTAssertThrowsError(
+            try cautiousKeyedContainer.encode(Int8(4), forKey: .value)
+        )
     }
 
     func testSimpleKeyEncode_Int16() throws {
@@ -76,9 +114,23 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(4)))
     }
 
+    func testSimpleKeyEncode_Int16_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .F64(4.0))
+        XCTAssertThrowsError(
+            try cautiousKeyedContainer.encode(Int16(4), forKey: .value)
+        )
+    }
+
     func testSimpleKeyEncode_Int32() throws {
         try rootKeyedContainer.encode(Int32(4), forKey: .value)
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(4)))
+    }
+
+    func testSimpleKeyEncode_Int32_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .F64(4.0))
+        XCTAssertThrowsError(
+            try cautiousKeyedContainer.encode(Int32(4), forKey: .value)
+        )
     }
 
     func testSimpleKeyEncode_Int64() throws {
@@ -86,9 +138,30 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(4)))
     }
 
+    func testSimpleKeyEncode_Int64_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .F64(4.0))
+        XCTAssertThrowsError(
+            try cautiousKeyedContainer.encode(Int64(4), forKey: .value)
+        )
+    }
+
+    func testSimpleKeyEncode_Int_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .F64(4.0))
+        XCTAssertThrowsError(
+            try cautiousKeyedContainer.encode(Int(4), forKey: .value)
+        )
+    }
+
     func testSimpleKeyEncode_UInt() throws {
         try rootKeyedContainer.encode(UInt(4), forKey: .value)
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(4)))
+    }
+
+    func testSimpleKeyEncode_UInt_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .F64(4.0))
+        XCTAssertThrowsError(
+            try cautiousKeyedContainer.encode(UInt(4), forKey: .value)
+        )
     }
 
     func testSimpleKeyEncode_UInt8() throws {
@@ -96,9 +169,23 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(4)))
     }
 
+    func testSimpleKeyEncode_UInt8_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .F64(4.0))
+        XCTAssertThrowsError(
+            try cautiousKeyedContainer.encode(UInt8(4), forKey: .value)
+        )
+    }
+
     func testSimpleKeyEncode_UInt16() throws {
         try rootKeyedContainer.encode(UInt16(4), forKey: .value)
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(4)))
+    }
+
+    func testSimpleKeyEncode_UInt16_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .F64(4.0))
+        XCTAssertThrowsError(
+            try cautiousKeyedContainer.encode(UInt16(4), forKey: .value)
+        )
     }
 
     func testSimpleKeyEncode_UInt32() throws {
@@ -106,16 +193,36 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(4)))
     }
 
+    func testSimpleKeyEncode_UInt32_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .F64(4.0))
+        XCTAssertThrowsError(
+            try cautiousKeyedContainer.encode(UInt32(4), forKey: .value)
+        )
+    }
+
     func testSimpleKeyEncode_UInt64() throws {
         try rootKeyedContainer.encode(UInt64(4), forKey: .value)
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(4)))
     }
 
-    // NEED TO MAKE COUNTER conform to Codable
-//    func testSimpleKeyEncode_Counter() throws {
-//        try rootKeyedContainer.encode(Counter(4), forKey: .value)
-//        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(4)))
-//    }
+    func testSimpleKeyEncode_UInt64_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .F64(4.0))
+        XCTAssertThrowsError(
+            try cautiousKeyedContainer.encode(UInt64(4), forKey: .value)
+        )
+    }
+
+    func testSimpleKeyEncode_Counter() throws {
+        try rootKeyedContainer.encode(Counter(4), forKey: .value)
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Counter(4)))
+    }
+
+    func testSimpleKeyEncode_Counter_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .F64(4.0))
+        XCTAssertThrowsError(
+            try cautiousKeyedContainer.encode(Counter(4), forKey: .value)
+        )
+    }
 
     func testErrorEncode_Bool() throws {
         let impl = AutomergeEncoderImpl(

--- a/Tests/AutomergeSwiftAdditionsTests/AutomergeKeyEncoderImplTests.swift
+++ b/Tests/AutomergeSwiftAdditionsTests/AutomergeKeyEncoderImplTests.swift
@@ -55,8 +55,8 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
             XCTFail("Scalar Float value not retrieved.")
         }
 
-        try rootKeyedContainer.encode(Float(3.4), forKey: .value)
-        try rootKeyedContainer.encode(Double(7.8), forKey: .value)
+        try cautiousKeyedContainer.encode(Float(3.4), forKey: .value)
+        try cautiousKeyedContainer.encode(Double(7.8), forKey: .value)
     }
 
     func testErrorEncode_Float() throws {
@@ -97,7 +97,7 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
         try rootKeyedContainer.encode(Int8(4), forKey: .value)
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(4)))
 
-        try rootKeyedContainer.encode(Int8(5), forKey: .value)
+        try cautiousKeyedContainer.encode(Int8(5), forKey: .value)
     }
 
     func testSimpleKeyEncode_Int8_CautiousFailure() throws {
@@ -111,7 +111,7 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
         try rootKeyedContainer.encode(Int16(4), forKey: .value)
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(4)))
 
-        try rootKeyedContainer.encode(Int16(5), forKey: .value)
+        try cautiousKeyedContainer.encode(Int16(5), forKey: .value)
     }
 
     func testSimpleKeyEncode_Int16_CautiousFailure() throws {
@@ -139,7 +139,7 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
         try rootKeyedContainer.encode(Int64(4), forKey: .value)
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(4)))
 
-        try rootKeyedContainer.encode(Int64(5), forKey: .value)
+        try cautiousKeyedContainer.encode(Int64(5), forKey: .value)
     }
 
     func testSimpleKeyEncode_Int64_CautiousFailure() throws {
@@ -160,7 +160,7 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
         try rootKeyedContainer.encode(UInt(4), forKey: .value)
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(4)))
 
-        try rootKeyedContainer.encode(UInt(5), forKey: .value)
+        try cautiousKeyedContainer.encode(UInt(5), forKey: .value)
     }
 
     func testSimpleKeyEncode_UInt_CautiousFailure() throws {
@@ -174,7 +174,7 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
         try rootKeyedContainer.encode(UInt8(4), forKey: .value)
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(4)))
 
-        try rootKeyedContainer.encode(UInt8(5), forKey: .value)
+        try cautiousKeyedContainer.encode(UInt8(5), forKey: .value)
     }
 
     func testSimpleKeyEncode_UInt8_CautiousFailure() throws {
@@ -188,7 +188,7 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
         try rootKeyedContainer.encode(UInt16(4), forKey: .value)
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(4)))
 
-        try rootKeyedContainer.encode(UInt16(5), forKey: .value)
+        try cautiousKeyedContainer.encode(UInt16(5), forKey: .value)
     }
 
     func testSimpleKeyEncode_UInt16_CautiousFailure() throws {
@@ -201,7 +201,7 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
     func testSimpleKeyEncode_UInt32() throws {
         try rootKeyedContainer.encode(UInt32(4), forKey: .value)
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(4)))
-        try rootKeyedContainer.encode(UInt32(5), forKey: .value)
+        try cautiousKeyedContainer.encode(UInt32(5), forKey: .value)
     }
 
     func testSimpleKeyEncode_UInt32_CautiousFailure() throws {
@@ -214,7 +214,7 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
     func testSimpleKeyEncode_UInt64() throws {
         try rootKeyedContainer.encode(UInt64(4), forKey: .value)
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(4)))
-        try rootKeyedContainer.encode(UInt64(5), forKey: .value)
+        try cautiousKeyedContainer.encode(UInt64(5), forKey: .value)
     }
 
     func testSimpleKeyEncode_UInt64_CautiousFailure() throws {
@@ -228,13 +228,28 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
         try rootKeyedContainer.encode(Counter(4), forKey: .value)
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Counter(4)))
 
-        try rootKeyedContainer.encode(Counter(45), forKey: .value)
+        try cautiousKeyedContainer.encode(Counter(45), forKey: .value)
     }
 
     func testSimpleKeyEncode_Counter_CautiousFailure() throws {
         try doc.put(obj: ObjId.ROOT, key: "value", value: .F64(4.0))
         XCTAssertThrowsError(
             try cautiousKeyedContainer.encode(Counter(4), forKey: .value)
+        )
+    }
+
+    func testSimpleKeyEncode_Data() throws {
+        try rootKeyedContainer.encode(Data("Hello".utf8), forKey: .value)
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Bytes(Data("Hello".utf8))))
+
+        try cautiousKeyedContainer.encode(Data("World".utf8), forKey: .value)
+    }
+
+    func testSimpleKeyEncode_Date_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .F64(4.0))
+        let earlyDate = try Date("1941-04-26T08:17:00Z", strategy: .iso8601)
+        XCTAssertThrowsError(
+            try cautiousKeyedContainer.encode(earlyDate, forKey: .value)
         )
     }
 

--- a/Tests/AutomergeSwiftAdditionsTests/AutomergeKeyEncoderImplTests.swift
+++ b/Tests/AutomergeSwiftAdditionsTests/AutomergeKeyEncoderImplTests.swift
@@ -1,10 +1,3 @@
-//
-//  AutomergeEncoderImpl+RetrieveTests.swift
-//  AMTravelNotesTests
-//
-//  Created by Joseph Heck on 5/16/23.
-//
-
 import Automerge
 @testable import AutomergeSwiftAdditions
 import XCTest
@@ -61,6 +54,9 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
         } else {
             XCTFail("Scalar Float value not retrieved.")
         }
+
+        try rootKeyedContainer.encode(Float(3.4), forKey: .value)
+        try rootKeyedContainer.encode(Double(7.8), forKey: .value)
     }
 
     func testErrorEncode_Float() throws {
@@ -100,6 +96,8 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
     func testSimpleKeyEncode_Int8() throws {
         try rootKeyedContainer.encode(Int8(4), forKey: .value)
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(4)))
+
+        try rootKeyedContainer.encode(Int8(5), forKey: .value)
     }
 
     func testSimpleKeyEncode_Int8_CautiousFailure() throws {
@@ -112,6 +110,8 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
     func testSimpleKeyEncode_Int16() throws {
         try rootKeyedContainer.encode(Int16(4), forKey: .value)
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(4)))
+
+        try rootKeyedContainer.encode(Int16(5), forKey: .value)
     }
 
     func testSimpleKeyEncode_Int16_CautiousFailure() throws {
@@ -124,6 +124,8 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
     func testSimpleKeyEncode_Int32() throws {
         try rootKeyedContainer.encode(Int32(4), forKey: .value)
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(4)))
+
+        try rootKeyedContainer.encode(Int32(5), forKey: .value)
     }
 
     func testSimpleKeyEncode_Int32_CautiousFailure() throws {
@@ -136,6 +138,8 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
     func testSimpleKeyEncode_Int64() throws {
         try rootKeyedContainer.encode(Int64(4), forKey: .value)
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(4)))
+
+        try rootKeyedContainer.encode(Int64(5), forKey: .value)
     }
 
     func testSimpleKeyEncode_Int64_CautiousFailure() throws {
@@ -155,6 +159,8 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
     func testSimpleKeyEncode_UInt() throws {
         try rootKeyedContainer.encode(UInt(4), forKey: .value)
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(4)))
+
+        try rootKeyedContainer.encode(UInt(5), forKey: .value)
     }
 
     func testSimpleKeyEncode_UInt_CautiousFailure() throws {
@@ -167,6 +173,8 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
     func testSimpleKeyEncode_UInt8() throws {
         try rootKeyedContainer.encode(UInt8(4), forKey: .value)
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(4)))
+
+        try rootKeyedContainer.encode(UInt8(5), forKey: .value)
     }
 
     func testSimpleKeyEncode_UInt8_CautiousFailure() throws {
@@ -179,6 +187,8 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
     func testSimpleKeyEncode_UInt16() throws {
         try rootKeyedContainer.encode(UInt16(4), forKey: .value)
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(4)))
+
+        try rootKeyedContainer.encode(UInt16(5), forKey: .value)
     }
 
     func testSimpleKeyEncode_UInt16_CautiousFailure() throws {
@@ -191,6 +201,7 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
     func testSimpleKeyEncode_UInt32() throws {
         try rootKeyedContainer.encode(UInt32(4), forKey: .value)
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(4)))
+        try rootKeyedContainer.encode(UInt32(5), forKey: .value)
     }
 
     func testSimpleKeyEncode_UInt32_CautiousFailure() throws {
@@ -203,6 +214,7 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
     func testSimpleKeyEncode_UInt64() throws {
         try rootKeyedContainer.encode(UInt64(4), forKey: .value)
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(4)))
+        try rootKeyedContainer.encode(UInt64(5), forKey: .value)
     }
 
     func testSimpleKeyEncode_UInt64_CautiousFailure() throws {
@@ -215,6 +227,8 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
     func testSimpleKeyEncode_Counter() throws {
         try rootKeyedContainer.encode(Counter(4), forKey: .value)
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Counter(4)))
+
+        try rootKeyedContainer.encode(Counter(45), forKey: .value)
     }
 
     func testSimpleKeyEncode_Counter_CautiousFailure() throws {

--- a/Tests/AutomergeSwiftAdditionsTests/AutomergeKeyedEncoderDecoderTests.swift
+++ b/Tests/AutomergeSwiftAdditionsTests/AutomergeKeyedEncoderDecoderTests.swift
@@ -4,9 +4,13 @@ import XCTest
 
 final class AutomergeKeyedEncoderDecoderTests: XCTestCase {
     var doc: Document!
+    var encoder: AutomergeEncoder!
+    var decoder: AutomergeDecoder!
 
     override func setUp() {
         doc = Document()
+        encoder = AutomergeEncoder(doc: doc)
+        decoder = AutomergeDecoder(doc: doc)
     }
 
     func testSimpleEncodeDecode() throws {
@@ -20,9 +24,6 @@ final class AutomergeKeyedEncoderDecoderTests: XCTestCase {
             let uuid: UUID
             let notes: Text
         }
-
-        let encoder = AutomergeEncoder(doc: doc)
-        let decoder = AutomergeDecoder(doc: doc)
 
         let earlyDate = try Date("1941-04-26T08:17:00Z", strategy: .iso8601)
 
@@ -48,9 +49,6 @@ final class AutomergeKeyedEncoderDecoderTests: XCTestCase {
             let counter: Counter
         }
 
-        let encoder = AutomergeEncoder(doc: doc)
-        let decoder = AutomergeDecoder(doc: doc)
-
         let topLevel = WrapperStruct(counter: Counter(5))
 
         try encoder.encode(topLevel)
@@ -63,9 +61,6 @@ final class AutomergeKeyedEncoderDecoderTests: XCTestCase {
             let counter: Counter?
             let anotherOptional: String?
         }
-
-        let encoder = AutomergeEncoder(doc: doc)
-        let decoder = AutomergeDecoder(doc: doc)
 
         let topLevel = WrapperStruct(counter: Counter(5), anotherOptional: nil)
 
@@ -80,9 +75,6 @@ final class AutomergeKeyedEncoderDecoderTests: XCTestCase {
             let thing: Float
         }
 
-        let encoder = AutomergeEncoder(doc: doc)
-        let decoder = AutomergeDecoder(doc: doc)
-
         let topLevel = WrapperStruct(thing: 3.0)
 
         try encoder.encode(topLevel)
@@ -94,9 +86,6 @@ final class AutomergeKeyedEncoderDecoderTests: XCTestCase {
         struct WrapperStruct: Codable, Equatable {
             let thing: Double
         }
-
-        let encoder = AutomergeEncoder(doc: doc)
-        let decoder = AutomergeDecoder(doc: doc)
 
         let topLevel = WrapperStruct(thing: 3.0)
 
@@ -110,9 +99,6 @@ final class AutomergeKeyedEncoderDecoderTests: XCTestCase {
             let thing: Int8
         }
 
-        let encoder = AutomergeEncoder(doc: doc)
-        let decoder = AutomergeDecoder(doc: doc)
-
         let topLevel = WrapperStruct(thing: 3)
 
         try encoder.encode(topLevel)
@@ -124,9 +110,6 @@ final class AutomergeKeyedEncoderDecoderTests: XCTestCase {
         struct WrapperStruct: Codable, Equatable {
             let thing: Int16
         }
-
-        let encoder = AutomergeEncoder(doc: doc)
-        let decoder = AutomergeDecoder(doc: doc)
 
         let topLevel = WrapperStruct(thing: 3)
 
@@ -140,9 +123,6 @@ final class AutomergeKeyedEncoderDecoderTests: XCTestCase {
             let thing: Int32
         }
 
-        let encoder = AutomergeEncoder(doc: doc)
-        let decoder = AutomergeDecoder(doc: doc)
-
         let topLevel = WrapperStruct(thing: 3)
 
         try encoder.encode(topLevel)
@@ -154,9 +134,6 @@ final class AutomergeKeyedEncoderDecoderTests: XCTestCase {
         struct WrapperStruct: Codable, Equatable {
             let thing: Int64
         }
-
-        let encoder = AutomergeEncoder(doc: doc)
-        let decoder = AutomergeDecoder(doc: doc)
 
         let topLevel = WrapperStruct(thing: 3)
 
@@ -170,9 +147,6 @@ final class AutomergeKeyedEncoderDecoderTests: XCTestCase {
             let thing: Int
         }
 
-        let encoder = AutomergeEncoder(doc: doc)
-        let decoder = AutomergeDecoder(doc: doc)
-
         let topLevel = WrapperStruct(thing: 3)
 
         try encoder.encode(topLevel)
@@ -184,9 +158,6 @@ final class AutomergeKeyedEncoderDecoderTests: XCTestCase {
         struct WrapperStruct: Codable, Equatable {
             let thing: UInt8
         }
-
-        let encoder = AutomergeEncoder(doc: doc)
-        let decoder = AutomergeDecoder(doc: doc)
 
         let topLevel = WrapperStruct(thing: 3)
 
@@ -200,9 +171,6 @@ final class AutomergeKeyedEncoderDecoderTests: XCTestCase {
             let thing: UInt16
         }
 
-        let encoder = AutomergeEncoder(doc: doc)
-        let decoder = AutomergeDecoder(doc: doc)
-
         let topLevel = WrapperStruct(thing: 3)
 
         try encoder.encode(topLevel)
@@ -214,9 +182,6 @@ final class AutomergeKeyedEncoderDecoderTests: XCTestCase {
         struct WrapperStruct: Codable, Equatable {
             let thing: UInt32
         }
-
-        let encoder = AutomergeEncoder(doc: doc)
-        let decoder = AutomergeDecoder(doc: doc)
 
         let topLevel = WrapperStruct(thing: 3)
 
@@ -230,9 +195,6 @@ final class AutomergeKeyedEncoderDecoderTests: XCTestCase {
             let thing: UInt64
         }
 
-        let encoder = AutomergeEncoder(doc: doc)
-        let decoder = AutomergeDecoder(doc: doc)
-
         let topLevel = WrapperStruct(thing: 3)
 
         try encoder.encode(topLevel)
@@ -245,9 +207,6 @@ final class AutomergeKeyedEncoderDecoderTests: XCTestCase {
             let thing: UInt
         }
 
-        let encoder = AutomergeEncoder(doc: doc)
-        let decoder = AutomergeDecoder(doc: doc)
-
         let topLevel = WrapperStruct(thing: 3)
 
         try encoder.encode(topLevel)
@@ -259,9 +218,6 @@ final class AutomergeKeyedEncoderDecoderTests: XCTestCase {
         struct WrapperStruct: Codable, Equatable {
             let thing: Date
         }
-
-        let encoder = AutomergeEncoder(doc: doc)
-        let decoder = AutomergeDecoder(doc: doc)
 
         let earlyDate = try Date("1941-04-26T08:17:00Z", strategy: .iso8601)
         let topLevel = WrapperStruct(thing: earlyDate)
@@ -276,9 +232,6 @@ final class AutomergeKeyedEncoderDecoderTests: XCTestCase {
             let thing: Data
         }
 
-        let encoder = AutomergeEncoder(doc: doc)
-        let decoder = AutomergeDecoder(doc: doc)
-
         let topLevel = WrapperStruct(thing: Data("Hello".utf8))
 
         try encoder.encode(topLevel)
@@ -290,9 +243,6 @@ final class AutomergeKeyedEncoderDecoderTests: XCTestCase {
         struct WrapperStruct: Codable, Equatable {
             let thing: Text
         }
-
-        let encoder = AutomergeEncoder(doc: doc)
-        let decoder = AutomergeDecoder(doc: doc)
 
         let topLevel = WrapperStruct(thing: Text("hi"))
 

--- a/Tests/AutomergeSwiftAdditionsTests/AutomergeSingleValueEncoderImplTests.swift
+++ b/Tests/AutomergeSwiftAdditionsTests/AutomergeSingleValueEncoderImplTests.swift
@@ -201,7 +201,7 @@ final class AutomergeSingleValueEncoderImplTests: XCTestCase {
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Timestamp(-905182980)))
 
         let anotherDate = try Date("1942-04-26T08:17:00Z", strategy: .iso8601)
-        try singleValueContainer.encode(anotherDate)
+        try cautiousSingleValueContainer.encode(anotherDate)
     }
 
     func testSimpleKeyEncode_Date_CautiousFailure() throws {
@@ -217,13 +217,13 @@ final class AutomergeSingleValueEncoderImplTests: XCTestCase {
         try singleValueContainer.encode(data)
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Bytes(data)))
 
-        try singleValueContainer.encode(Data("World".utf8))
+        try cautiousSingleValueContainer.encode(Data("World".utf8))
     }
 
     func testSimpleKeyEncode_Data_CautiousFailure() throws {
         try doc.put(obj: ObjId.ROOT, key: "value", value: .String("40"))
         XCTAssertThrowsError(
-            try singleValueContainer.encode(Data("World".utf8))
+            try cautiousSingleValueContainer.encode(Data("World".utf8))
         )
     }
 
@@ -241,13 +241,13 @@ final class AutomergeSingleValueEncoderImplTests: XCTestCase {
         try singleValueContainer.encode(Counter(4))
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Counter(4)))
 
-        try singleValueContainer.encode(Counter(14))
+        try cautiousSingleValueContainer.encode(Counter(14))
     }
 
     func testSimpleKeyEncode_Counter_CautiousFailure() throws {
         try doc.put(obj: ObjId.ROOT, key: "value", value: .String("40"))
         XCTAssertThrowsError(
-            try singleValueContainer.encode(Counter(443))
+            try cautiousSingleValueContainer.encode(Counter(443))
         )
     }
 

--- a/Tests/AutomergeSwiftAdditionsTests/AutomergeSingleValueEncoderImplTests.swift
+++ b/Tests/AutomergeSwiftAdditionsTests/AutomergeSingleValueEncoderImplTests.swift
@@ -22,7 +22,8 @@ final class AutomergeSingleValueEncoderImplTests: XCTestCase {
             userInfo: [:],
             codingPath: [AnyCodingKey("value")],
             doc: doc,
-            strategy: .createWhenNeeded
+            strategy: .createWhenNeeded,
+            cautiousWrite: false
         )
         singleValueContainer = impl.singleValueContainer()
     }
@@ -131,7 +132,8 @@ final class AutomergeSingleValueEncoderImplTests: XCTestCase {
             userInfo: [:],
             codingPath: [AnyCodingKey("nothere"), AnyCodingKey("value")],
             doc: doc,
-            strategy: .readonly
+            strategy: .readonly,
+            cautiousWrite: false
         )
         singleValueContainer = impl.singleValueContainer()
         XCTAssertThrowsError(try singleValueContainer.encode(true))
@@ -142,7 +144,8 @@ final class AutomergeSingleValueEncoderImplTests: XCTestCase {
             userInfo: [:],
             codingPath: [AnyCodingKey("nothere"), AnyCodingKey("value")],
             doc: doc,
-            strategy: .readonly
+            strategy: .readonly,
+            cautiousWrite: false
         )
         singleValueContainer = impl.singleValueContainer()
         XCTAssertThrowsError(try singleValueContainer.encode(Float(3.4)))
@@ -153,7 +156,8 @@ final class AutomergeSingleValueEncoderImplTests: XCTestCase {
             userInfo: [:],
             codingPath: [AnyCodingKey("nothere"), AnyCodingKey("value")],
             doc: doc,
-            strategy: .readonly
+            strategy: .readonly,
+            cautiousWrite: false
         )
         singleValueContainer = impl.singleValueContainer()
         XCTAssertThrowsError(try singleValueContainer.encode(Double(8.16)))
@@ -164,7 +168,8 @@ final class AutomergeSingleValueEncoderImplTests: XCTestCase {
             userInfo: [:],
             codingPath: [AnyCodingKey("nothere"), AnyCodingKey("value")],
             doc: doc,
-            strategy: .readonly
+            strategy: .readonly,
+            cautiousWrite: false
         )
         singleValueContainer = impl.singleValueContainer()
         XCTAssertThrowsError(try singleValueContainer.encode(Int(8)))
@@ -175,7 +180,8 @@ final class AutomergeSingleValueEncoderImplTests: XCTestCase {
             userInfo: [:],
             codingPath: [AnyCodingKey("nothere"), AnyCodingKey("value")],
             doc: doc,
-            strategy: .readonly
+            strategy: .readonly,
+            cautiousWrite: false
         )
         singleValueContainer = impl.singleValueContainer()
         XCTAssertThrowsError(try singleValueContainer.encode(Int8(8)))
@@ -186,7 +192,8 @@ final class AutomergeSingleValueEncoderImplTests: XCTestCase {
             userInfo: [:],
             codingPath: [AnyCodingKey("nothere"), AnyCodingKey("value")],
             doc: doc,
-            strategy: .readonly
+            strategy: .readonly,
+            cautiousWrite: false
         )
         singleValueContainer = impl.singleValueContainer()
         XCTAssertThrowsError(try singleValueContainer.encode(Int16(8)))
@@ -197,7 +204,8 @@ final class AutomergeSingleValueEncoderImplTests: XCTestCase {
             userInfo: [:],
             codingPath: [AnyCodingKey("nothere"), AnyCodingKey("value")],
             doc: doc,
-            strategy: .readonly
+            strategy: .readonly,
+            cautiousWrite: false
         )
         singleValueContainer = impl.singleValueContainer()
         XCTAssertThrowsError(try singleValueContainer.encode(Int32(8)))
@@ -208,7 +216,8 @@ final class AutomergeSingleValueEncoderImplTests: XCTestCase {
             userInfo: [:],
             codingPath: [AnyCodingKey("nothere"), AnyCodingKey("value")],
             doc: doc,
-            strategy: .readonly
+            strategy: .readonly,
+            cautiousWrite: false
         )
         singleValueContainer = impl.singleValueContainer()
         XCTAssertThrowsError(try singleValueContainer.encode(Int64(8)))
@@ -219,7 +228,8 @@ final class AutomergeSingleValueEncoderImplTests: XCTestCase {
             userInfo: [:],
             codingPath: [AnyCodingKey("nothere"), AnyCodingKey("value")],
             doc: doc,
-            strategy: .readonly
+            strategy: .readonly,
+            cautiousWrite: false
         )
         singleValueContainer = impl.singleValueContainer()
         XCTAssertThrowsError(try singleValueContainer.encode(UInt(8)))
@@ -230,7 +240,8 @@ final class AutomergeSingleValueEncoderImplTests: XCTestCase {
             userInfo: [:],
             codingPath: [AnyCodingKey("nothere"), AnyCodingKey("value")],
             doc: doc,
-            strategy: .readonly
+            strategy: .readonly,
+            cautiousWrite: false
         )
         singleValueContainer = impl.singleValueContainer()
         XCTAssertThrowsError(try singleValueContainer.encode(UInt8(8)))
@@ -241,7 +252,8 @@ final class AutomergeSingleValueEncoderImplTests: XCTestCase {
             userInfo: [:],
             codingPath: [AnyCodingKey("nothere"), AnyCodingKey("value")],
             doc: doc,
-            strategy: .readonly
+            strategy: .readonly,
+            cautiousWrite: false
         )
         singleValueContainer = impl.singleValueContainer()
         XCTAssertThrowsError(try singleValueContainer.encode(UInt16(8)))
@@ -252,7 +264,8 @@ final class AutomergeSingleValueEncoderImplTests: XCTestCase {
             userInfo: [:],
             codingPath: [AnyCodingKey("nothere"), AnyCodingKey("value")],
             doc: doc,
-            strategy: .readonly
+            strategy: .readonly,
+            cautiousWrite: false
         )
         singleValueContainer = impl.singleValueContainer()
         XCTAssertThrowsError(try singleValueContainer.encode(UInt32(8)))
@@ -263,7 +276,8 @@ final class AutomergeSingleValueEncoderImplTests: XCTestCase {
             userInfo: [:],
             codingPath: [AnyCodingKey("nothere"), AnyCodingKey("value")],
             doc: doc,
-            strategy: .readonly
+            strategy: .readonly,
+            cautiousWrite: false
         )
         singleValueContainer = impl.singleValueContainer()
         XCTAssertThrowsError(try singleValueContainer.encode(UInt64(8)))
@@ -274,7 +288,8 @@ final class AutomergeSingleValueEncoderImplTests: XCTestCase {
             userInfo: [:],
             codingPath: [AnyCodingKey("nothere"), AnyCodingKey("value")],
             doc: doc,
-            strategy: .readonly
+            strategy: .readonly,
+            cautiousWrite: false
         )
         singleValueContainer = impl.singleValueContainer()
         XCTAssertThrowsError(try singleValueContainer.encode(Text("hi")))
@@ -285,7 +300,8 @@ final class AutomergeSingleValueEncoderImplTests: XCTestCase {
             userInfo: [:],
             codingPath: [AnyCodingKey("nothere"), AnyCodingKey("value")],
             doc: doc,
-            strategy: .readonly
+            strategy: .readonly,
+            cautiousWrite: false
         )
         let earlyDate = try Date("1941-04-26T08:17:00Z", strategy: .iso8601)
         singleValueContainer = impl.singleValueContainer()
@@ -297,7 +313,8 @@ final class AutomergeSingleValueEncoderImplTests: XCTestCase {
             userInfo: [:],
             codingPath: [AnyCodingKey("nothere"), AnyCodingKey("value")],
             doc: doc,
-            strategy: .readonly
+            strategy: .readonly,
+            cautiousWrite: false
         )
         singleValueContainer = impl.singleValueContainer()
         XCTAssertThrowsError(try singleValueContainer.encode(Data("Hello".utf8)))
@@ -312,7 +329,8 @@ final class AutomergeSingleValueEncoderImplTests: XCTestCase {
             userInfo: [:],
             codingPath: [AnyCodingKey("nothere")],
             doc: doc,
-            strategy: .readonly
+            strategy: .readonly,
+            cautiousWrite: false
         )
         singleValueContainer = impl.singleValueContainer()
         XCTAssertThrowsError(try singleValueContainer.encode(SimpleStruct(a: "foo")))

--- a/Tests/AutomergeSwiftAdditionsTests/AutomergeSingleValueEncoderImplTests.swift
+++ b/Tests/AutomergeSwiftAdditionsTests/AutomergeSingleValueEncoderImplTests.swift
@@ -1,10 +1,3 @@
-//
-//  AutomergeEncoderImpl+RetrieveTests.swift
-//  AMTravelNotesTests
-//
-//  Created by Joseph Heck on 5/16/23.
-//
-
 import Automerge
 @testable import AutomergeSwiftAdditions
 import XCTest
@@ -12,6 +5,8 @@ import XCTest
 final class AutomergeSingleValueEncoderImplTests: XCTestCase {
     var doc: Document!
     var singleValueContainer: SingleValueEncodingContainer!
+    var cautiousSingleValueContainer: SingleValueEncodingContainer!
+
     enum SampleCodingKeys: String, CodingKey {
         case value
     }
@@ -26,17 +21,42 @@ final class AutomergeSingleValueEncoderImplTests: XCTestCase {
             cautiousWrite: false
         )
         singleValueContainer = impl.singleValueContainer()
+        let cautious = AutomergeEncoderImpl(
+            userInfo: [:],
+            codingPath: [AnyCodingKey("value")],
+            doc: doc,
+            strategy: .createWhenNeeded,
+            cautiousWrite: true
+        )
+        cautiousSingleValueContainer = cautious.singleValueContainer()
     }
 
     func testSimpleKeyEncode_Bool() throws {
         try singleValueContainer.encode(true)
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Boolean(true)))
+
+        try cautiousSingleValueContainer.encode(false)
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Boolean(false)))
+    }
+
+    func testSimpleKeyEncode_Bool_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .F64(4.0))
+        XCTAssertThrowsError(
+            try cautiousSingleValueContainer.encode(true)
+        )
     }
 
     func testSimpleKeyEncode_Float() throws {
         try singleValueContainer.encode(Float(4.3))
         if case let .Scalar(.F64(floatValue)) = try doc.get(obj: ObjId.ROOT, key: "value") {
             XCTAssertEqual(floatValue, 4.3, accuracy: 0.01)
+        } else {
+            XCTFail("Scalar Float value not retrieved.")
+        }
+
+        try cautiousSingleValueContainer.encode(Float(3.4))
+        if case let .Scalar(.F64(floatValue)) = try doc.get(obj: ObjId.ROOT, key: "value") {
+            XCTAssertEqual(floatValue, 3.4, accuracy: 0.01)
         } else {
             XCTFail("Scalar Float value not retrieved.")
         }
@@ -54,61 +74,157 @@ final class AutomergeSingleValueEncoderImplTests: XCTestCase {
         )
     }
 
+    func testSimpleKeyEncode_Double_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .Int(40))
+        XCTAssertThrowsError(
+            try cautiousSingleValueContainer.encode(Double(3.4))
+        )
+
+        XCTAssertThrowsError(
+            try cautiousSingleValueContainer.encode(Float(3.4))
+        )
+    }
+
     func testSimpleKeyEncode_Int8() throws {
         try singleValueContainer.encode(Int8(4))
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(4)))
+
+        try cautiousSingleValueContainer.encode(Int8(5))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(5)))
+    }
+
+    func testSimpleKeyEncode_Int_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .String("40"))
+        XCTAssertThrowsError(
+            try cautiousSingleValueContainer.encode(Int(4))
+        )
+        XCTAssertThrowsError(
+            try cautiousSingleValueContainer.encode(Int8(4))
+        )
+        XCTAssertThrowsError(
+            try cautiousSingleValueContainer.encode(Int16(4))
+        )
+        XCTAssertThrowsError(
+            try cautiousSingleValueContainer.encode(Int32(4))
+        )
+        XCTAssertThrowsError(
+            try cautiousSingleValueContainer.encode(Int64(4))
+        )
     }
 
     func testSimpleKeyEncode_Int16() throws {
         try singleValueContainer.encode(Int16(4))
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(4)))
+
+        try cautiousSingleValueContainer.encode(Int16(5))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(5)))
     }
 
     func testSimpleKeyEncode_Int32() throws {
         try singleValueContainer.encode(Int32(4))
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(4)))
+
+        try cautiousSingleValueContainer.encode(Int32(5))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(5)))
     }
 
     func testSimpleKeyEncode_Int64() throws {
         try singleValueContainer.encode(Int64(4))
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(4)))
+
+        try cautiousSingleValueContainer.encode(Int64(5))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(5)))
     }
 
     func testSimpleKeyEncode_UInt() throws {
         try singleValueContainer.encode(UInt(4))
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(4)))
+
+        try cautiousSingleValueContainer.encode(UInt(5))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(5)))
     }
 
     func testSimpleKeyEncode_UInt8() throws {
         try singleValueContainer.encode(UInt8(4))
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(4)))
+
+        try cautiousSingleValueContainer.encode(UInt8(5))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(5)))
     }
 
     func testSimpleKeyEncode_UInt16() throws {
         try singleValueContainer.encode(UInt16(4))
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(4)))
+
+        try cautiousSingleValueContainer.encode(UInt16(5))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(5)))
     }
 
     func testSimpleKeyEncode_UInt32() throws {
         try singleValueContainer.encode(UInt32(4))
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(4)))
+
+        try cautiousSingleValueContainer.encode(UInt32(5))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(5)))
     }
 
     func testSimpleKeyEncode_UInt64() throws {
         try singleValueContainer.encode(UInt64(4))
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(4)))
+
+        try cautiousSingleValueContainer.encode(UInt64(5))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(5)))
+    }
+
+    func testSimpleKeyEncode_UInt_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .String("40"))
+        XCTAssertThrowsError(
+            try cautiousSingleValueContainer.encode(UInt(4))
+        )
+        XCTAssertThrowsError(
+            try cautiousSingleValueContainer.encode(UInt8(4))
+        )
+        XCTAssertThrowsError(
+            try cautiousSingleValueContainer.encode(UInt16(4))
+        )
+        XCTAssertThrowsError(
+            try cautiousSingleValueContainer.encode(UInt32(4))
+        )
+        XCTAssertThrowsError(
+            try cautiousSingleValueContainer.encode(UInt64(4))
+        )
     }
 
     func testSimpleKeyEncode_Date() throws {
         let earlyDate = try Date("1941-04-26T08:17:00Z", strategy: .iso8601)
         try singleValueContainer.encode(earlyDate)
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Timestamp(-905182980)))
+
+        let anotherDate = try Date("1942-04-26T08:17:00Z", strategy: .iso8601)
+        try singleValueContainer.encode(anotherDate)
+    }
+
+    func testSimpleKeyEncode_Date_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .String("40"))
+        let earlyDate = try Date("1941-04-26T08:17:00Z", strategy: .iso8601)
+        XCTAssertThrowsError(
+            try cautiousSingleValueContainer.encode(earlyDate)
+        )
     }
 
     func testSimpleKeyEncode_Data() throws {
         let data = Data("Hello".utf8)
         try singleValueContainer.encode(data)
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Bytes(data)))
+
+        try singleValueContainer.encode(Data("World".utf8))
+    }
+
+    func testSimpleKeyEncode_Data_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .String("40"))
+        XCTAssertThrowsError(
+            try singleValueContainer.encode(Data("World".utf8))
+        )
     }
 
     func testSimpleKeyEncode_Text() throws {
@@ -121,11 +237,19 @@ final class AutomergeSingleValueEncoderImplTests: XCTestCase {
         }
     }
 
-    // NEED TO MAKE COUNTER conform to Codable
-//    func testSimpleKeyEncode_Counter() throws {
-//        try rootKeyedContainer.encode(Counter(4), forKey: .value)
-//        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(4)))
-//    }
+    func testSimpleKeyEncode_Counter() throws {
+        try singleValueContainer.encode(Counter(4))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Counter(4)))
+
+        try singleValueContainer.encode(Counter(14))
+    }
+
+    func testSimpleKeyEncode_Counter_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .String("40"))
+        XCTAssertThrowsError(
+            try singleValueContainer.encode(Counter(443))
+        )
+    }
 
     func testErrorEncode_Bool() throws {
         let impl = AutomergeEncoderImpl(

--- a/Tests/AutomergeSwiftAdditionsTests/AutomergeUnkeyedEncoderDecoderTests.swift
+++ b/Tests/AutomergeSwiftAdditionsTests/AutomergeUnkeyedEncoderDecoderTests.swift
@@ -4,9 +4,13 @@ import XCTest
 
 final class AutomergeUnkeyedEncoderDecoderTests: XCTestCase {
     var doc: Document!
+    var encoder: AutomergeEncoder!
+    var decoder: AutomergeDecoder!
 
     override func setUp() {
         doc = Document()
+        encoder = AutomergeEncoder(doc: doc)
+        decoder = AutomergeDecoder(doc: doc)
     }
 
     func testListOfSimpleEncodeDecode() throws {
@@ -24,9 +28,6 @@ final class AutomergeUnkeyedEncoderDecoderTests: XCTestCase {
             let uuid: UUID
             let notes: Text
         }
-
-        let encoder = AutomergeEncoder(doc: doc)
-        let decoder = AutomergeDecoder(doc: doc)
 
         let earlyDate = try Date("1941-04-26T08:17:00Z", strategy: .iso8601)
 
@@ -54,9 +55,6 @@ final class AutomergeUnkeyedEncoderDecoderTests: XCTestCase {
             let list: [Float]
         }
 
-        let encoder = AutomergeEncoder(doc: doc)
-        let decoder = AutomergeDecoder(doc: doc)
-
         let topLevel = WrapperStruct(list: [3.0])
 
         try encoder.encode(topLevel)
@@ -69,9 +67,6 @@ final class AutomergeUnkeyedEncoderDecoderTests: XCTestCase {
         struct WrapperStruct: Codable, Equatable {
             let list: [Float]
         }
-
-        let encoder = AutomergeEncoder(doc: doc)
-        let decoder = AutomergeDecoder(doc: doc)
 
         let topLevel = WrapperStruct(list: [3.0])
 
@@ -86,9 +81,6 @@ final class AutomergeUnkeyedEncoderDecoderTests: XCTestCase {
             let list: [Int8]
         }
 
-        let encoder = AutomergeEncoder(doc: doc)
-        let decoder = AutomergeDecoder(doc: doc)
-
         let topLevel = WrapperStruct(list: [3])
 
         try encoder.encode(topLevel)
@@ -101,9 +93,6 @@ final class AutomergeUnkeyedEncoderDecoderTests: XCTestCase {
         struct WrapperStruct: Codable, Equatable {
             let list: [Int16]
         }
-
-        let encoder = AutomergeEncoder(doc: doc)
-        let decoder = AutomergeDecoder(doc: doc)
 
         let topLevel = WrapperStruct(list: [3])
 
@@ -118,9 +107,6 @@ final class AutomergeUnkeyedEncoderDecoderTests: XCTestCase {
             let list: [Int32]
         }
 
-        let encoder = AutomergeEncoder(doc: doc)
-        let decoder = AutomergeDecoder(doc: doc)
-
         let topLevel = WrapperStruct(list: [3])
 
         try encoder.encode(topLevel)
@@ -133,9 +119,6 @@ final class AutomergeUnkeyedEncoderDecoderTests: XCTestCase {
         struct WrapperStruct: Codable, Equatable {
             let list: [Int64]
         }
-
-        let encoder = AutomergeEncoder(doc: doc)
-        let decoder = AutomergeDecoder(doc: doc)
 
         let topLevel = WrapperStruct(list: [3])
 
@@ -150,9 +133,6 @@ final class AutomergeUnkeyedEncoderDecoderTests: XCTestCase {
             let list: [Int]
         }
 
-        let encoder = AutomergeEncoder(doc: doc)
-        let decoder = AutomergeDecoder(doc: doc)
-
         let topLevel = WrapperStruct(list: [3])
 
         try encoder.encode(topLevel)
@@ -165,9 +145,6 @@ final class AutomergeUnkeyedEncoderDecoderTests: XCTestCase {
         struct WrapperStruct: Codable, Equatable {
             let list: [UInt8]
         }
-
-        let encoder = AutomergeEncoder(doc: doc)
-        let decoder = AutomergeDecoder(doc: doc)
 
         let topLevel = WrapperStruct(list: [3])
 
@@ -182,9 +159,6 @@ final class AutomergeUnkeyedEncoderDecoderTests: XCTestCase {
             let list: [UInt16]
         }
 
-        let encoder = AutomergeEncoder(doc: doc)
-        let decoder = AutomergeDecoder(doc: doc)
-
         let topLevel = WrapperStruct(list: [3])
 
         try encoder.encode(topLevel)
@@ -197,9 +171,6 @@ final class AutomergeUnkeyedEncoderDecoderTests: XCTestCase {
         struct WrapperStruct: Codable, Equatable {
             let list: [UInt32]
         }
-
-        let encoder = AutomergeEncoder(doc: doc)
-        let decoder = AutomergeDecoder(doc: doc)
 
         let topLevel = WrapperStruct(list: [3])
 
@@ -214,9 +185,6 @@ final class AutomergeUnkeyedEncoderDecoderTests: XCTestCase {
             let list: [UInt64]
         }
 
-        let encoder = AutomergeEncoder(doc: doc)
-        let decoder = AutomergeDecoder(doc: doc)
-
         let topLevel = WrapperStruct(list: [3])
 
         try encoder.encode(topLevel)
@@ -230,9 +198,6 @@ final class AutomergeUnkeyedEncoderDecoderTests: XCTestCase {
             let list: [UInt]
         }
 
-        let encoder = AutomergeEncoder(doc: doc)
-        let decoder = AutomergeDecoder(doc: doc)
-
         let topLevel = WrapperStruct(list: [3])
 
         try encoder.encode(topLevel)
@@ -245,9 +210,6 @@ final class AutomergeUnkeyedEncoderDecoderTests: XCTestCase {
         struct WrapperStruct: Codable, Equatable {
             let list: [Date]
         }
-
-        let encoder = AutomergeEncoder(doc: doc)
-        let decoder = AutomergeDecoder(doc: doc)
 
         let earlyDate = try Date("1941-04-26T08:17:00Z", strategy: .iso8601)
         let topLevel = WrapperStruct(list: [earlyDate])
@@ -263,9 +225,6 @@ final class AutomergeUnkeyedEncoderDecoderTests: XCTestCase {
             let list: [Data]
         }
 
-        let encoder = AutomergeEncoder(doc: doc)
-        let decoder = AutomergeDecoder(doc: doc)
-
         let topLevel = WrapperStruct(list: [Data("Hello".utf8)])
 
         try encoder.encode(topLevel)
@@ -279,9 +238,6 @@ final class AutomergeUnkeyedEncoderDecoderTests: XCTestCase {
             let list: [Text]
         }
 
-        let encoder = AutomergeEncoder(doc: doc)
-        let decoder = AutomergeDecoder(doc: doc)
-
         let topLevel = WrapperStruct(list: [Text("hi")])
 
         try encoder.encode(topLevel)
@@ -294,9 +250,6 @@ final class AutomergeUnkeyedEncoderDecoderTests: XCTestCase {
         struct WrapperStruct: Codable, Equatable {
             let list: [Counter]
         }
-
-        let encoder = AutomergeEncoder(doc: doc)
-        let decoder = AutomergeDecoder(doc: doc)
 
         let topLevel = WrapperStruct(list: [Counter(3)])
 


### PR DESCRIPTION
enabling additional encoder option that does a cautious write:
- for any written value, checks the existing type in the Automerge document, and IF it exists, verifies the same type is about to be written.